### PR TITLE
Allow empty ammunition and disregard stowed ammunition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.3 - 2022-03-04
+- Revert system change to disregard empty ammunition stacks
+- Prevent unloading into stowed ammunition stacks
+
 ## 2.1.2 - 2022-02-26
 - Add a dialog when first being unable to fire a weapon because of the module, linking to documentation
 

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
     "title": "PF2e Ranged Combat",
     "description": "Utilities for impriving ranged combat in Pathfinder 2e.",
     "author": "JDCalvert",
-    "version": "2.1.2",
+    "version": "2.1.3",
     "minimumCoreVersion": "9",
     "compatibleCoreVersion": "9",
     "system": [
@@ -16,7 +16,7 @@
     ],
     "url": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat",
     "manifest": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/releases/latest/download/module.json",
-    "download": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/archive/2.1.2.zip",
+    "download": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/archive/2.1.3.zip",
     "readme": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat",
     "bugs": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/issues",
     "changelog": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/blob/main/CHANGELOG.md",

--- a/scripts/actions/reload.js
+++ b/scripts/actions/reload.js
@@ -50,7 +50,7 @@ export async function reload() {
                 ui.notifications.warn(`${weapon.name} has no ammunition selected.`);
                 return;
             } else if (ammo.quantity < 1) {
-                ui.notifications.warn(`Not enough ammunition to reload ${weapon.name}`);
+                ui.notifications.warn(`Not enough ammunition to reload ${weapon.name}.`);
                 return;
             }
 
@@ -224,8 +224,8 @@ async function unloadAmmunition(actor, loadedEffect, itemsToAdd, itemsToRemove, 
     const loadedSourceId = loadedEffect.getFlag("pf2e-ranged-combat", "ammunitionSourceId");
 
     // Try to find either the stack the loaded ammunition came from, or another stack of the same ammunition
-    const ammunitionItem = actor.items.find(item => item.id === loadedItemId)
-        || actor.items.find(item => item.sourceId === loadedSourceId);
+    const ammunitionItem = actor.items.find(item => item.id === loadedItemId && !item.isStowed)
+        || actor.items.find(item => item.sourceId === loadedSourceId && !item.isStowed);
 
     if (ammunitionItem) {
         // We still have the stack the ammunition originally came from, or another that's the same.
@@ -253,10 +253,10 @@ async function unloadMagazine(actor, magazineLoadedEffect, itemsToAdd, itemsToRe
     const ammunitionRemaining = magazineLoadedEffect.getFlag("pf2e-ranged-combat", "remaining");
 
     const ammunitionItemId = magazineLoadedEffect.getFlag("pf2e-ranged-combat", "ammunitionItemId");
-    const ammunitionItem = actor.items.find(item => item.id === ammunitionItemId);
+    const ammunitionItem = actor.items.find(item => item.id === ammunitionItemId && !item.isStowed);
 
     if (ammunitionRemaining === ammunitionCapacity && ammunitionItem) {
-        // The magazine is full, but we've got different ammunition selected, so switch to that
+        // We found the original stack of ammunition this
         itemsToUpdate.push(() => {
             ammunitionItem.update({
                 "data.quantity.value": ammunitionItem.quantity + 1

--- a/scripts/fire-weapon-hook.js
+++ b/scripts/fire-weapon-hook.js
@@ -14,6 +14,16 @@ Hooks.on(
 
         libWrapper.register(
             "pf2e-ranged-combat",
+            "CONFIG.PF2E.Item.documentClasses.weapon.prototype.ammo",
+            function() {
+                const ammo = this.actor?.items.get(this.data.data.selectedAmmoId ?? "");
+                return ammo?.type === "consumable" ? ammo : null;
+            },
+            "OVERRIDE"
+        );
+
+        libWrapper.register(
+            "pf2e-ranged-combat",
             "game.pf2e.Check.roll",
             async function (wrapper, ...args) {
                 const context = args[1];


### PR DESCRIPTION
### Allow Empty Ammunition Stacks
The Pathfinder 2e system recently updated so that, if a stack of ammunition was empty (stack size 0) it was not considered to be chosen ammunition. Also, the system added a check that weapons that require ammunition must have ammunition chosen to fire.

In this module, the change prevented firing a weapon if its ammunition stack was empty, even if it was loaded.

I've overridden `WeaponPF2e.ammo` so even empty ammunition counts.

### Disregard Stowed Ammunition Stacks
The system recently added a change to prevent stowed (in a container) ammunition stacks from being selected as ammunition for weapons.

I've updated the unload action to ignore stowed stacks when trying to find a stack to unload to, creating a new un-stowed stack if necessary.