### PR TITLE
Fix Hunt Prey not applying Crossbow Ace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.6 - 2022-03-18 (Pathfinder 2e 3.7.2)
+- Fix issue where Hunt Prey did not apply Crossbow Ace effect due to system data change
+
 ## 2.1.5 - 2022-03-14 (Pathfinder 2e 3.7.1)
 - Update to support data structure changes in Pathfinder 2e 3.7.0 (thanks to MrVauxs)
 

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
     "title": "PF2e Ranged Combat",
     "description": "Utilities for impriving ranged combat in Pathfinder 2e.",
     "author": "JDCalvert",
-    "version": "2.1.5",
+    "version": "2.1.6",
     "minimumCoreVersion": "9",
     "compatibleCoreVersion": "9",
     "system": [
@@ -16,7 +16,7 @@
     ],
     "url": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat",
     "manifest": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/releases/latest/download/module.json",
-    "download": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/archive/2.1.5.zip",
+    "download": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/archive/2.1.6.zip",
     "readme": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat",
     "bugs": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/issues",
     "changelog": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/blob/main/CHANGELOG.md",

--- a/scripts/actions/hunt-prey.js
+++ b/scripts/actions/hunt-prey.js
@@ -80,12 +80,11 @@ export async function huntPrey() {
 
 function getCrossbows(actor) {
     return actor.itemTypes.weapon
-        .map(weapon => weapon.data)
-        .filter(weapon => weapon.data.equipped.value)
-        .filter(weapon => weapon.data.traits.otherTags.includes("crossbow"))
+        .filter(weapon => weapon.isEquipped)
+        .filter(weapon => weapon.data.data.traits.otherTags.includes("crossbow"))
         .map(weapon => {
             return {
-                id: weapon._id,
+                id: weapon.id,
                 name: weapon.name
             }
         });


### PR DESCRIPTION
Fixed an issue where, due to a change in the Pathfinder 2e system data structure, crossbows were no longer considered wielded for the purpose of applying the Crossbow Ace effect when using the Hunt Prey macro.