### PR TITLE
Remove Crossbow Ace and Crossbow Crackshot effects automatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.7 - ??? (Pathfinder 2e ???)
+- Automatically remove the Crossbow Ace and Crossbow Crack Shot effects upon dealing damage or making a second attack roll
+
 ## 2.1.6 - 2022-03-18 (Pathfinder 2e 3.7.2)
 - Fix issue where Hunt Prey did not apply Crossbow Ace effect due to system data change
 

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
     "title": "PF2e Ranged Combat",
     "description": "Utilities for impriving ranged combat in Pathfinder 2e.",
     "author": "JDCalvert",
-    "version": "2.1.6",
+    "version": "2.1.7",
     "minimumCoreVersion": "9",
     "compatibleCoreVersion": "9",
     "system": [
@@ -16,7 +16,7 @@
     ],
     "url": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat",
     "manifest": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/releases/latest/download/module.json",
-    "download": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/archive/2.1.6.zip",
+    "download": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/archive/2.1.7.zip",
     "readme": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat",
     "bugs": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/issues",
     "changelog": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/blob/main/CHANGELOG.md",

--- a/scripts/actions/hunt-prey.js
+++ b/scripts/actions/hunt-prey.js
@@ -9,8 +9,8 @@ export async function huntPrey() {
 
     const updates = new Updates(actor);
 
-    if (!Utils.actorHasItem(actor, Utils.HUNT_PREY_ACTION_ID)) {
-        ui.notifications.warn(`${token.name} does not have the Hunt Prey action.`);
+    if (!Utils.actorHasItem(actor, Utils.HUNT_PREY_FEATURE_ID)) {
+        ui.notifications.warn(`${token.name} does not have the Hunt Prey feature.`);
         return;
     }
 
@@ -29,13 +29,13 @@ export async function huntPrey() {
      * HUNT PREY ACTION AND EFFECT
      */
     {
-        const myHuntPreyAction = await Utils.getItemFromActor(actor, Utils.HUNT_PREY_ACTION_ID);
+        const huntPreyFeature = await Utils.getItemFromActor(actor, Utils.HUNT_PREY_FEATURE_ID);
         await Utils.postActionInChat(actor, Utils.HUNT_PREY_ACTION_ID);
         await Utils.postInChat(
             actor,
-            Utils.HUNT_PREY_IMG,
+            huntPreyFeature.img,
             `${token.name} makes ${target.name} their hunted prey.`,
-            myHuntPreyAction.name,
+            huntPreyFeature.name,
             1
         );
 
@@ -54,7 +54,7 @@ export async function huntPrey() {
         updates.add(huntedPreyEffect);
 
         // Set the Hunt Prey flag, since we're currently targetting our hunted prey
-        actor.setFlag("pf2e", "rollOptions.all.hunted-prey", true);
+        updates.update(() => actor.setFlag("pf2e", "rollOptions.all.hunted-prey", true));
     }
 
     /**

--- a/scripts/fire-weapon-hook.js
+++ b/scripts/fire-weapon-hook.js
@@ -98,6 +98,17 @@ Hooks.on(
                 const itemsToRemove = [];
                 const itemsToUpdate = [];
 
+                // Crossbow Ace and Crossbow Crack Shot only apply to the next shot fired. If that shot hadn't
+                // already been fired, it has now. If it had already been fired, remove the effect.
+                const crossbowAceEffect = Utils.getEffectFromActor(actor, Utils.CROSSBOW_ACE_EFFECT_ID, weapon.id);
+                if (crossbowAceEffect) {
+                    if (crossbowAceEffect.data.flags["pf2e-ranged-combat"].fired) {
+                        itemsToRemove.push(crossbowAceEffect);
+                    } else {
+                        itemsToUpdate.push(() => crossbowAceEffect.update({ "flags.pf2e-ranged-combat.fired": true }));
+                    }
+                }
+
                 // Remove the loaded effect if the weapon requires reloading. It could have a loaded effect
                 // and not require reloading e.g. combination weapons
                 const loadedEffect = Utils.getEffectFromActor(actor, Utils.LOADED_EFFECT_ID, weapon.id);

--- a/scripts/fire-weapon-hook.js
+++ b/scripts/fire-weapon-hook.js
@@ -95,17 +95,18 @@ Hooks.on(
                     return;
                 }
 
-                const itemsToRemove = [];
-                const itemsToUpdate = [];
+                const updates = new Utils.Updates(actor);
 
                 // Crossbow Ace and Crossbow Crack Shot only apply to the next shot fired. If that shot hadn't
                 // already been fired, it has now. If it had already been fired, remove the effect.
-                const crossbowAceEffect = Utils.getEffectFromActor(actor, Utils.CROSSBOW_ACE_EFFECT_ID, weapon.id);
-                if (crossbowAceEffect) {
-                    if (crossbowAceEffect.data.flags["pf2e-ranged-combat"].fired) {
-                        itemsToRemove.push(crossbowAceEffect);
-                    } else {
-                        itemsToUpdate.push(() => crossbowAceEffect.update({ "flags.pf2e-ranged-combat.fired": true }));
+                for (const effectId of [Utils.CROSSBOW_ACE_EFFECT_ID, Utils.CROSSBOW_CRACK_SHOT_EFFECT_ID]) {
+                    const effect = Utils.getEffectFromActor(actor, effectId, weapon.id);
+                    if (effect) {
+                        if (effect.data.flags["pf2e-ranged-combat"].fired) {
+                            updates.remove(effect);
+                        } else {
+                            updates.update(() => effect.update({ "flags.pf2e-ranged-combat.fired": true }));
+                        }
                     }
                 }
 
@@ -113,7 +114,7 @@ Hooks.on(
                 // and not require reloading e.g. combination weapons
                 const loadedEffect = Utils.getEffectFromActor(actor, Utils.LOADED_EFFECT_ID, weapon.id);
                 if (loadedEffect && Utils.requiresLoading(weapon)) {
-                    itemsToRemove.push(loadedEffect);
+                    updates.remove(loadedEffect);
                 }
 
                 // If the advanced ammunition system is not enabled, consume a piece of ammunition
@@ -126,7 +127,7 @@ Hooks.on(
 
                         magazineLoadedEffect.setFlag("pf2e-ranged-combat", "remaining", magazineRemaining);
                         const magazineLoadedEffectName = magazineLoadedEffect.getFlag("pf2e-ranged-combat", "name");
-                        itemsToUpdate.push(async () => {
+                        updates.update(async () => {
                             await magazineLoadedEffect.update({
                                 "name": `${magazineLoadedEffectName} (${magazineRemaining}/${magazineCapacity})`
                             });
@@ -155,7 +156,7 @@ Hooks.on(
                         );
                     } else if (Utils.usesAmmunition(weapon)) {
                         const ammo = Utils.getAmmunition(weapon);
-                        itemsToUpdate.push(async () => {
+                        updates.update(async () => {
                             await ammo.update({
                                 "data.quantity": ammo.quantity - 1
                             });
@@ -166,7 +167,7 @@ Hooks.on(
                     weapon.ammo?.consume();
                 }
 
-                Utils.handleUpdates(actor, [], itemsToRemove, itemsToUpdate);
+                updates.handleUpdates();
 
                 return roll;
             },

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -10,6 +10,7 @@ export const RELOAD_ACTION_THREE_ID = "Compendium.pf2e-ranged-combat.actions.IOh
 export const RELOAD_ACTION_EXPLORE_ID = "Compendium.pf2e-ranged-combat.actions.t8xTgsZqOIW02suc";
 
 // Hunt Prey
+export const HUNT_PREY_FEATURE_ID = "Compendium.pf2e.classfeatures.0nIOGpHQNHsKSFKT";
 export const HUNT_PREY_ACTION_ID = "Compendium.pf2e.actionspf2e.JYi4MnsdFu618hPm";
 export const HUNTED_PREY_EFFECT_ID = "Compendium.pf2e-ranged-combat.effects.rdLADYwOByj8AZ7r";
 
@@ -22,7 +23,6 @@ export const CROSSBOW_CRACK_SHOT_FEAT_ID = "Compendium.pf2e.feats-srd.s6h0xkdKf3
 export const CROSSBOW_CRACK_SHOT_EFFECT_ID = "Compendium.pf2e-ranged-combat.effects.hG9i3aOBDZ9Bq9yi";
 
 // Images
-export const HUNT_PREY_IMG = "systems/pf2e/icons/features/classes/hunt-prey.webp";
 export const RELOAD_AMMUNITION_IMG = "modules/pf2e-ranged-combat/art/reload_ammunition.webp";
 export const RELOAD_MAGAZINE_IMG = "modules/pf2e-ranged-combat/art/reload_magazine.webp";
 export const UNLOAD_IMG = "modules/pf2e-ranged-combat/art/unload.webp";
@@ -31,9 +31,9 @@ export const CONSOLIDATE_AMMUNITION_IMG = "modules/pf2e-ranged-combat/art/consol
 export class Updates {
     constructor(actor) {
         this.actor = actor;
-        this.itemsToAdd = new [];
-        this.itemsToRemove = new [];
-        this.itemsToUpdate = new [];
+        this.itemsToAdd = [];
+        this.itemsToRemove = [];
+        this.itemsToUpdate = [];
     }
 
     add(item) {
@@ -46,6 +46,10 @@ export class Updates {
 
     update(update) {
         this.itemsToUpdate.push(update);
+    }
+
+    hasChanges() {
+        return this.itemsToAdd.length || this.itemsToUpdate.length || this.itemsToRemove.length;
     }
 
     async handleUpdates() {


### PR DESCRIPTION
The Crossbow Ace and Crossbow Crack Shot feats should only apply to the first shot made after their respective triggers, so now, we'll automatically remove the Crossbow Ace and Crossbow Crack Shot effects upon making a second attack roll using the effect's weapon. This will mostly only affect repeating weapons with reload 0, as other weapons will replace the effect upon reload.