### PR TITLE
Improve flag get and set performance

### DIFF
--- a/scripts/actions/reload.js
+++ b/scripts/actions/reload.js
@@ -26,7 +26,7 @@ export async function reload() {
             if (!magazineLoadedEffect) {
                 ui.notifications.warn(`${weapon.name} has no magazine loaded!`);
                 return;
-            } else if (magazineLoadedEffect.getFlag("pf2e-ranged-combat", "remaining") < 1) {
+            } else if (Utils.getFlag(magazineLoadedEffect, "remaining") < 1) {
                 ui.notifications.warn(`${weapon.name}'s magazine is empty!`);
                 return;
             }
@@ -59,7 +59,7 @@ export async function reload() {
             const loadedEffect = Utils.getEffectFromActor(actor, Utils.LOADED_EFFECT_ID, weapon.id);
             if (loadedEffect) {
                 // If the selected ammunition is the same as what's already loaded, don't reload
-                const loadedSourceId = loadedEffect.getFlag("pf2e-ranged-combat", "ammunitionSourceId");
+                const loadedSourceId = Utils.getFlag(loadedEffect, "ammunitionSourceId");
                 if (ammo.sourceId === loadedSourceId) {
                     ui.notifications.warn(`${weapon.name} is already loaded with ${ammo.name}.`);
                     return;
@@ -162,10 +162,10 @@ export async function reloadMagazine() {
     // we'll put it back in our inventory
     const magazineLoadedEffect = Utils.getEffectFromActor(actor, Utils.MAGAZINE_LOADED_EFFECT_ID, weapon.id);
     if (magazineLoadedEffect) {
-        const magazineRemaining = magazineLoadedEffect.getFlag("pf2e-ranged-combat", "remaining");
-        const magazineCapacity = magazineLoadedEffect.getFlag("pf2e-ranged-combat", "capacity");
+        const magazineRemaining = Utils.getFlag(magazineLoadedEffect, "remaining");
+        const magazineCapacity = Utils.getFlag(magazineLoadedEffect, "capacity");
 
-        const magazineSourceId = magazineLoadedEffect.getFlag("pf2e-ranged-combat", "ammunitionSourceId");
+        const magazineSourceId = Utils.getFlag(magazineLoadedEffect, "ammunitionSourceId");
         const selectedAmmunitionSourceId = ammo.sourceId;
 
         if (magazineRemaining === magazineCapacity && magazineSourceId === selectedAmmunitionSourceId) {
@@ -224,8 +224,8 @@ export async function reloadMagazine() {
 }
 
 async function unloadAmmunition(actor, loadedEffect, updates) {
-    const loadedItemId = loadedEffect.getFlag("pf2e-ranged-combat", "ammunitionItemId");
-    const loadedSourceId = loadedEffect.getFlag("pf2e-ranged-combat", "ammunitionSourceId");
+    const loadedItemId = Utils.getFlag(loadedEffect, "ammunitionItemId");
+    const loadedSourceId = Utils.getFlag(loadedEffect, "ammunitionSourceId");
 
     // Try to find either the stack the loaded ammunition came from, or another stack of the same ammunition
     const ammunitionItem = actor.items.find(item => item.id === loadedItemId && !item.isStowed)
@@ -253,10 +253,10 @@ async function unloadAmmunition(actor, loadedEffect, updates) {
  * Remove the magazine effect and add the remaining ammunition back to the actor
  */
 async function unloadMagazine(actor, magazineLoadedEffect, updates) {
-    const ammunitionCapacity = magazineLoadedEffect.getFlag("pf2e-ranged-combat", "capacity");
-    const ammunitionRemaining = magazineLoadedEffect.getFlag("pf2e-ranged-combat", "remaining");
+    const ammunitionCapacity = Utils.getFlag(magazineLoadedEffect, "capacity");
+    const ammunitionRemaining = Utils.getFlag(magazineLoadedEffect, "remaining");
 
-    const ammunitionItemId = magazineLoadedEffect.getFlag("pf2e-ranged-combat", "ammunitionItemId");
+    const ammunitionItemId = Utils.getFlag(magazineLoadedEffect, "ammunitionItemId");
     const ammunitionItem = actor.items.find(item => item.id === ammunitionItemId && !item.isStowed);
 
     if (ammunitionRemaining === ammunitionCapacity && ammunitionItem) {
@@ -268,7 +268,7 @@ async function unloadMagazine(actor, magazineLoadedEffect, updates) {
         });
     } else if (ammunitionRemaining > 0) {
         // The magazine still has some ammunition left, create a new item with the remaining ammunition
-        const itemSourceId = magazineLoadedEffect.getFlag("pf2e-ranged-combat", "ammunitionSourceId");
+        const itemSourceId = Utils.getFlag(magazineLoadedEffect, "ammunitionSourceId");
         const ammunitionSource = await Utils.getItem(itemSourceId);
         ammunitionSource.data.charges.value = ammunitionRemaining;
         updates.add(ammunitionSource);
@@ -278,7 +278,7 @@ async function unloadMagazine(actor, magazineLoadedEffect, updates) {
     updates.remove(magazineLoadedEffect);
 
     // If the weapon was loaded, then remove the loaded status as well
-    const weaponId = magazineLoadedEffect.getFlag("pf2e-ranged-combat", "targetId");
+    const weaponId = Utils.getFlag(magazineLoadedEffect, "targetId");
     const loadedEffect = Utils.getEffectFromActor(actor, Utils.LOADED_EFFECT_ID, weaponId);
     if (loadedEffect) {
         updates.remove(loadedEffect);
@@ -348,7 +348,7 @@ export async function unload() {
                     Utils.postInChat(
                         actor,
                         magazineLoadedEffect.img,
-                        `${token.name} unloads ${magazineLoadedEffect.getFlag("pf2e-ranged-combat", "ammunitionName")} from their ${weapon.name}.`,
+                        `${token.name} unloads ${Utils.getFlag(magazineLoadedEffect, "ammunitionName")} from their ${weapon.name}.`,
                         "Interact",
                         "1"
                     );
@@ -359,7 +359,7 @@ export async function unload() {
                     Utils.postInChat(
                         actor,
                         loadedEffect.img,
-                        `${token.name} unloads ${loadedEffect.getFlag("pf2e-ranged-combat", "ammunitionName")} from their ${weapon.name}.`,
+                        `${token.name} unloads ${Utils.getFlag(loadedEffect, "ammunitionName")} from their ${weapon.name}.`,
                         "Interact",
                         "1"
                     );

--- a/scripts/fire-weapon-hook.js
+++ b/scripts/fire-weapon-hook.js
@@ -48,7 +48,7 @@ Hooks.on(
                         if (!magazineLoadedEffect) {
                             Utils.showWarning(`${weapon.name} has no magazine loaded!`);
                             return;
-                        } else if (magazineLoadedEffect.getFlag("pf2e-ranged-combat", "remaining") < 1) {
+                        } else if (Utils.getFlag(magazineLoadedEffect, "remaining") < 1) {
                             Utils.showWarning(`${weapon.name}'s magazine is empty!`);
                             return;
                         }
@@ -133,11 +133,11 @@ Hooks.on(
                     // Use up a round of the loaded magazine
                     if (weapon.isRepeating) {
                         const magazineLoadedEffect = Utils.getEffectFromActor(actor, Utils.MAGAZINE_LOADED_EFFECT_ID, weapon.id);
-                        const magazineCapacity = magazineLoadedEffect.getFlag("pf2e-ranged-combat", "capacity");
-                        const magazineRemaining = magazineLoadedEffect.getFlag("pf2e-ranged-combat", "remaining") - 1;
+                        const magazineCapacity = Utils.getFlag(magazineLoadedEffect, "capacity");
+                        const magazineRemaining = Utils.getFlag(magazineLoadedEffect, "remaining") - 1;
 
                         magazineLoadedEffect.setFlag("pf2e-ranged-combat", "remaining", magazineRemaining);
-                        const magazineLoadedEffectName = magazineLoadedEffect.getFlag("pf2e-ranged-combat", "name");
+                        const magazineLoadedEffectName = Utils.getFlag(magazineLoadedEffect, "name");
                         updates.update(async () => {
                             await magazineLoadedEffect.update({
                                 "name": `${magazineLoadedEffectName} (${magazineRemaining}/${magazineCapacity})`
@@ -148,7 +148,7 @@ Hooks.on(
                         for (const token of tokens) {
                             token.showFloatyText({
                                 update: {
-                                    name: `${magazineLoadedEffect.getFlag("pf2e-ranged-combat", "ammunitionName")} ${magazineRemaining}/${magazineCapacity}`
+                                    name: `${Utils.getFlag(magazineLoadedEffect, "ammunitionName")} ${magazineRemaining}/${magazineCapacity}`
                                 }
                             });
                         }
@@ -163,8 +163,8 @@ Hooks.on(
                         } else {
                             Utils.postInChat(
                                 actor,
-                                magazineLoadedEffect.getFlag("pf2e-ranged-combat", "ammunitionImg"),
-                                `${actor.name} uses ${magazineLoadedEffect.getFlag("pf2e-ranged-combat", "ammunitionName")} (${magazineRemaining}/${magazineCapacity} remaining).`
+                                Utils.getFlag(magazineLoadedEffect, "ammunitionImg"),
+                                `${actor.name} uses ${Utils.getFlag(magazineLoadedEffect, "ammunitionName")} (${magazineRemaining}/${magazineCapacity} remaining).`
                             );
                         }
 
@@ -178,8 +178,8 @@ Hooks.on(
                         } else {
                             Utils.postInChat(
                                 actor,
-                                loadedEffect.getFlag("pf2e-ranged-combat", "ammunitionImg"),
-                                `${actor.name} uses ${loadedEffect.getFlag("pf2e-ranged-combat", "ammunitionName")}.`
+                                Utils.getFlag(loadedEffect, "ammunitionImg"),
+                                `${actor.name} uses ${Utils.getFlag(loadedEffect, "ammunitionName")}.`
                             );
                         }
 

--- a/scripts/fire-weapon-hook.js
+++ b/scripts/fire-weapon-hook.js
@@ -136,11 +136,11 @@ Hooks.on(
                         const magazineCapacity = Utils.getFlag(magazineLoadedEffect, "capacity");
                         const magazineRemaining = Utils.getFlag(magazineLoadedEffect, "remaining") - 1;
 
-                        magazineLoadedEffect.setFlag("pf2e-ranged-combat", "remaining", magazineRemaining);
                         const magazineLoadedEffectName = Utils.getFlag(magazineLoadedEffect, "name");
                         updates.update(async () => {
                             await magazineLoadedEffect.update({
-                                "name": `${magazineLoadedEffectName} (${magazineRemaining}/${magazineCapacity})`
+                                "name": `${magazineLoadedEffectName} (${magazineRemaining}/${magazineCapacity})`,
+                                "flags.pf2e-ranged-combat.remaining": magazineRemaining
                             });
                         });
                         // Show floaty text with the new effect name

--- a/scripts/utils/utils.js
+++ b/scripts/utils/utils.js
@@ -140,7 +140,7 @@ export async function getItemFromActor(actor, sourceId, addIfNotPresent = false)
 export function getEffectFromActor(actor, sourceId, targetId) {
     return actor.itemTypes.effect.find(effect =>
         effect.getFlag("core", "sourceId") === sourceId
-        && effect.getFlag("pf2e-ranged-combat", "targetId") === targetId
+        && Utils.getFlag(effect, "targetId") === targetId
     );
 }
 
@@ -241,4 +241,8 @@ export function showWarning(warningMessage) {
             }
         ).render(true);
     }
+}
+
+export function getFlag(item, flagName) {
+    return item.data.flags["pf2e-ranged-combat"][flagName];
 }

--- a/scripts/utils/utils.js
+++ b/scripts/utils/utils.js
@@ -140,7 +140,7 @@ export async function getItemFromActor(actor, sourceId, addIfNotPresent = false)
 export function getEffectFromActor(actor, sourceId, targetId) {
     return actor.itemTypes.effect.find(effect =>
         effect.getFlag("core", "sourceId") === sourceId
-        && Utils.getFlag(effect, "targetId") === targetId
+        && getFlag(effect, "targetId") === targetId
     );
 }
 


### PR DESCRIPTION
Replace the use of `getFlag` and `setFlag` with direct access and updates to improve performance.