### PR TITLE
Apply crossbow feats when reloading using Conjure Bullet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.8.2 - 2022-07-06 (Pathfinder 2e 3.12.2)
+- Apply Crossbow Ace and Crossbow Crack Shot when using Conjure Bullet
+
 ## 2.8.1 - 2022-06-26 (Pathfinder 2e 3.11.3)
 - Add missing file, which caused various parts of the module to break
 

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
     "title": "PF2e Ranged Combat",
     "description": "Utilities for improving ranged combat in Pathfinder 2e.",
     "author": "JDCalvert",
-    "version": "2.8.1",
+    "version": "2.8.2",
     "minimumCoreVersion": "9",
     "compatibleCoreVersion": "9",
     "system": [
@@ -16,7 +16,7 @@
     ],
     "url": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat",
     "manifest": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/releases/latest/download/module.json",
-    "download": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/archive/2.8.1.zip",
+    "download": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/archive/2.8.2.zip",
     "readme": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat",
     "bugs": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/issues",
     "changelog": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/blob/main/CHANGELOG.md",

--- a/scripts/ammunition-system/actions/conjure-bullet.js
+++ b/scripts/ammunition-system/actions/conjure-bullet.js
@@ -1,6 +1,7 @@
+import { handleReload } from "../../feats/crossbow-feats.js";
 import { getControlledActorAndToken, getEffectFromActor, getItem, getItemFromActor, postInChat, setEffectTarget, showWarning, Updates } from "../../utils/utils.js";
 import { getSingleWeapon, getWeapons } from "../../utils/weapon-utils.js";
-import { CONJURED_ROUND_ITEM_ID as CONJURED_ROUND_ITEM_ID, CONJURED_ROUND_EFFECT_ID, CONJURE_BULLET_ACTION_ID, CONJURE_BULLET_IMG } from "../constants.js";
+import { CONJURED_ROUND_EFFECT_ID, CONJURED_ROUND_ITEM_ID, CONJURE_BULLET_ACTION_ID, CONJURE_BULLET_IMG } from "../constants.js";
 import { checkFullyLoaded, isFullyLoaded } from "../utils.js";
 import { setLoadedChamber } from "./next-chamber.js";
 
@@ -67,6 +68,8 @@ export async function conjureBullet() {
         "Conjure Bullet",
         1,
     );
+
+    await handleReload(weapon, updates);
 
     updates.handleUpdates();
 }

--- a/scripts/ammunition-system/actions/reload-magazine.js
+++ b/scripts/ammunition-system/actions/reload-magazine.js
@@ -1,7 +1,7 @@
+import { handleReload } from "../../feats/crossbow-feats.js";
 import { getControlledActorAndToken, getEffectFromActor, getFlag, getItem, postInChat, setEffectTarget, showWarning, Updates, useAdvancedAmmunitionSystem } from "../../utils/utils.js";
 import { getWeapon } from "../../utils/weapon-utils.js";
 import { MAGAZINE_LOADED_EFFECT_ID, RELOAD_MAGAZINE_IMG } from "../constants.js";
-import { triggerCrossbowReloadEffects } from "../utils.js";
 import { unloadMagazine } from "./unload.js";
 
 /**
@@ -99,7 +99,7 @@ export async function reloadMagazine() {
 
     updates.add(magazineLoadedEffectSource);
 
-    await triggerCrossbowReloadEffects(actor, token, weapon, updates);
+    await handleReload(weapon, updates);
 
     numActions += 2;
 

--- a/scripts/ammunition-system/actions/reload.js
+++ b/scripts/ammunition-system/actions/reload.js
@@ -1,7 +1,8 @@
+import { handleReload } from "../../feats/crossbow-feats.js";
 import { getControlledActorAndToken, getEffectFromActor, getFlag, getItem, postInChat, setEffectTarget, showWarning, Updates, useAdvancedAmmunitionSystem } from "../../utils/utils.js";
 import { getSingleWeapon, getWeapons } from "../../utils/weapon-utils.js";
 import { CONJURED_ROUND_EFFECT_ID, LOADED_EFFECT_ID, MAGAZINE_LOADED_EFFECT_ID, RELOAD_AMMUNITION_IMG } from "../constants.js";
-import { buildLoadedEffectName, checkFullyLoaded, isFullyLoaded, triggerCrossbowReloadEffects } from "../utils.js";
+import { buildLoadedEffectName, checkFullyLoaded, isFullyLoaded } from "../utils.js";
 import { setLoadedChamber } from "./next-chamber.js";
 import { unloadAmmunition } from "./unload.js";
 
@@ -217,7 +218,7 @@ export async function reload() {
         await postReloadToChat(token, weapon);
     }
 
-    await triggerCrossbowReloadEffects(actor, token, weapon, updates);
+    await handleReload(weapon, updates);
 
     updates.handleUpdates();
 };

--- a/scripts/ammunition-system/utils.js
+++ b/scripts/ammunition-system/utils.js
@@ -1,6 +1,6 @@
 import { ItemSelectDialog } from "../utils/item-select-dialog.js";
-import { CROSSBOW_ACE_EFFECT_ID, CROSSBOW_ACE_FEAT_ID, CROSSBOW_CRACK_SHOT_EFFECT_ID, CROSSBOW_CRACK_SHOT_FEAT_ID, getEffectFromActor, getFlag, getFlags, getItem, getItemFromActor, setEffectTarget, showWarning } from "../utils/utils.js";
-import { CHAMBER_LOADED_EFFECT_ID, CONJURED_ROUND_ITEM_ID, CONJURED_ROUND_EFFECT_ID, LOADED_EFFECT_ID } from "./constants.js";
+import { getEffectFromActor, getFlag, getFlags, showWarning } from "../utils/utils.js";
+import { CHAMBER_LOADED_EFFECT_ID, CONJURED_ROUND_EFFECT_ID, CONJURED_ROUND_ITEM_ID, LOADED_EFFECT_ID } from "./constants.js";
 
 /**
  * Check if the weapon is fully loaded and, if it is, show a warning
@@ -155,39 +155,6 @@ export function clearLoadedChamber(actor, weapon, ammunition, updates) {
             }
         } else {
             updates.remove(chamberLoadedEffect);
-        }
-    }
-}
-
-export async function triggerCrossbowReloadEffects(actor, token, weapon, updates) {
-    const crossbowFeats = [
-        { featId: CROSSBOW_ACE_FEAT_ID, effectId: CROSSBOW_ACE_EFFECT_ID },
-        { featId: CROSSBOW_CRACK_SHOT_FEAT_ID, effectId: CROSSBOW_CRACK_SHOT_EFFECT_ID }
-    ];
-
-    // Handle crossbow effects that trigger on reload
-    if (weapon.isCrossbow && weapon.isEquipped) {
-        for (const crossbowFeat of crossbowFeats) {
-            const featId = crossbowFeat.featId;
-            const effectId = crossbowFeat.effectId;
-
-            if (getItemFromActor(actor, featId)) {
-                // Remove any existing effects
-                const existing = getEffectFromActor(actor, effectId, weapon.id);
-                if (existing) {
-                    updates.remove(existing);
-                }
-
-                // Add the new effect
-                const effect = await getItem(effectId);
-                setEffectTarget(effect, weapon);
-                effect.flags["pf2e-ranged-combat"].fired = false;
-                if (!token.inCombat && effect.data.duration.value === 0) {
-                    effect.data.duration.value = 1;
-                }
-
-                updates.add(effect);
-            }
         }
     }
 }

--- a/scripts/feats/crossbow-feats.js
+++ b/scripts/feats/crossbow-feats.js
@@ -1,0 +1,73 @@
+import { getEffectFromActor, getFlag, getItem, getItemFromActor, setEffectTarget } from "../utils/utils.js";
+import { getWeapons } from "../utils/weapon-utils.js";
+
+// Crossbow Ace
+export const CROSSBOW_ACE_FEAT_ID = "Compendium.pf2e.feats-srd.CpjN7v1QN8TQFcvI";
+export const CROSSBOW_ACE_EFFECT_ID = "Compendium.pf2e-ranged-combat.effects.zP0vPd14V5OG9ZFv";
+
+// Crossbow Crack Shot
+export const CROSSBOW_CRACK_SHOT_FEAT_ID = "Compendium.pf2e.feats-srd.s6h0xkdKf3gecLk6";
+export const CROSSBOW_CRACK_SHOT_EFFECT_ID = "Compendium.pf2e-ranged-combat.effects.hG9i3aOBDZ9Bq9yi";
+
+export async function handleReload(weapon, updates) {
+    // Both of these feats only activate if the weapon is an equipped crossbow
+    if (!weapon.isCrossbow || !weapon.isEquipped) {
+        return;
+    }
+
+    if (getItemFromActor(weapon.actor, CROSSBOW_ACE_FEAT_ID)) {
+        await applyFeatEffect(weapon, CROSSBOW_ACE_EFFECT_ID, updates);
+    }
+
+    if (getItemFromActor(weapon.actor, CROSSBOW_CRACK_SHOT_FEAT_ID)) {
+        await applyFeatEffect(weapon, CROSSBOW_CRACK_SHOT_EFFECT_ID, updates);
+    }
+}
+
+export async function handleHuntPrey(actor, updates) {
+    if (getItemFromActor(actor, CROSSBOW_ACE_FEAT_ID)) {
+        const weapons = getWeapons(actor, weapon => weapon.isEquipped && weapon.isCrossbow);
+        for (const weapon of weapons) {
+            await applyFeatEffect(weapon, CROSSBOW_ACE_EFFECT_ID, updates);
+        }
+    }
+}
+
+/**
+ * Handle what happens with these feat effects when a weapon is fired. Since they only last for one shot,
+ * we need to keep track of whether or not a shot has been fired for the effect already. If so, mark it
+ * as having had a shot fired. If a shot has already been fired, remove the effect.
+ */
+export function handleWeaponFired(weapon, updates) {
+    for (const effectId of [CROSSBOW_ACE_EFFECT_ID, CROSSBOW_CRACK_SHOT_EFFECT_ID]) {
+        const effect = getEffectFromActor(weapon.actor, effectId, weapon.id);
+        if (effect) {
+            if (getFlag(effect, "fired")) {
+                updates.remove(effect);
+            } else {
+                updates.update(() => effect.update({ "flags.pf2e-ranged-combat.fired": true }));
+            }
+        }
+    }
+}
+
+async function applyFeatEffect(weapon, effectId, updates) {
+    // Remove any existing effects
+    const existing = getEffectFromActor(weapon.actor, effectId, weapon.id);
+    if (existing) {
+        updates.remove(existing);
+    }
+
+    // Add the new effect
+    const effect = await getItem(effectId);
+    setEffectTarget(effect, weapon);
+    effect.flags["pf2e-ranged-combat"].fired = false;
+
+    // If the actor doesn't have at least one token that's in combat, then a duration of 0 will be immediately expired
+    // To prevent this, set the duration to 1 round
+    if (!weapon.actor.getActiveTokens().some(token => token.inCombat) && effect.data.duration.value === 0) {
+        effect.data.duration.value = 1;
+    }
+
+    updates.add(effect);
+}

--- a/scripts/fire-weapon-hook.js
+++ b/scripts/fire-weapon-hook.js
@@ -1,10 +1,11 @@
 import { handleWeaponFired as handleAlchemicalCrossbowFired } from "./actions/alchemical-crossbow.js";
 import { checkLoaded } from "./ammunition-system/fire-weapon-check.js";
 import { fireWeapon } from "./ammunition-system/fire-weapon-handler.js";
+import { handleWeaponFired as crossbowFeatsHandleFired } from "./feats/crossbow-feats.js";
 import { changeCarryType } from "./thrown-weapons/change-carry-type.js";
 import { checkThrownWeapon } from "./thrown-weapons/throw-weapon-check.js";
 import { handleThrownWeapon } from "./thrown-weapons/throw-weapon-handler.js";
-import { CROSSBOW_ACE_EFFECT_ID, CROSSBOW_CRACK_SHOT_EFFECT_ID, getEffectFromActor, getFlag, Updates } from "./utils/utils.js";
+import { Updates } from "./utils/utils.js";
 import { transformWeapon } from "./utils/weapon-utils.js";
 
 Hooks.on(
@@ -83,20 +84,8 @@ Hooks.on(
 
                 const updates = new Updates(actor);
 
-                // Some effects only apply to the next shot fired. If that shot hadn't
-                // already been fired, it has now. If it had already been fired, remove the effect.
-                for (const effectId of [CROSSBOW_ACE_EFFECT_ID, CROSSBOW_CRACK_SHOT_EFFECT_ID]) {
-                    const effect = getEffectFromActor(actor, effectId, weapon.id);
-                    if (effect) {
-                        if (getFlag(effect, "fired")) {
-                            updates.remove(effect);
-                        } else {
-                            updates.update(() => effect.update({ "flags.pf2e-ranged-combat.fired": true }));
-                        }
-                    }
-                }
-
                 // Run the various handlers for the weapon being used
+                crossbowFeatsHandleFired(weapon, updates);
                 handleAlchemicalCrossbowFired(actor, weapon, updates);
                 fireWeapon(actor, weapon, updates);
                 handleThrownWeapon(weapon, updates);

--- a/scripts/hunt-prey/hunt-prey.js
+++ b/scripts/hunt-prey/hunt-prey.js
@@ -1,5 +1,5 @@
-import { CROSSBOW_ACE_EFFECT_ID, CROSSBOW_ACE_FEAT_ID, getControlledActorAndToken, getEffectFromActor, getItem, getItemFromActor, getTarget, postActionInChat, postInChat, setEffectTarget, showWarning, Updates } from "../utils/utils.js";
-import { getWeapons } from "../utils/weapon-utils.js";
+import { handleHuntPrey } from "../feats/crossbow-feats.js";
+import { getControlledActorAndToken, getEffectFromActor, getItem, getItemFromActor, getTarget, postActionInChat, postInChat, setEffectTarget, showWarning, Updates } from "../utils/utils.js";
 
 export const HUNT_PREY_ACTION_ID = "Compendium.pf2e.actionspf2e.JYi4MnsdFu618hPm";
 export const HUNTED_PREY_EFFECT_ID = "Compendium.pf2e-ranged-combat.effects.rdLADYwOByj8AZ7r";
@@ -63,26 +63,7 @@ export async function huntPrey() {
         }
     }
 
-    /**
-     * CROSSBOW ACE
-     */
-    {
-        if (getItemFromActor(actor, CROSSBOW_ACE_FEAT_ID)) {
-            const weapons = getWeapons(actor, weapon => weapon.isEquipped && weapon.isCrossbow);
-            for (const weapon of weapons) {
-                const existing = getEffectFromActor(actor, CROSSBOW_ACE_EFFECT_ID, weapon.id);
-                if (existing) {
-                    updates.remove(existing);
-                }
-
-                const crossbowAceEffectSource = await getItem(CROSSBOW_ACE_EFFECT_ID);
-                setEffectTarget(crossbowAceEffectSource, weapon);
-                crossbowAceEffectSource.flags["pf2e-ranged-combat"].fired = false;
-
-                updates.add(crossbowAceEffectSource);
-            }
-        }
-    }
+    await handleHuntPrey(actor, updates);
 
     updates.handleUpdates();
 }

--- a/scripts/utils/utils.js
+++ b/scripts/utils/utils.js
@@ -1,11 +1,3 @@
-// Crossbow Ace
-export const CROSSBOW_ACE_FEAT_ID = "Compendium.pf2e.feats-srd.CpjN7v1QN8TQFcvI";
-export const CROSSBOW_ACE_EFFECT_ID = "Compendium.pf2e-ranged-combat.effects.zP0vPd14V5OG9ZFv";
-
-// Crossbow Crack Shot
-export const CROSSBOW_CRACK_SHOT_FEAT_ID = "Compendium.pf2e.feats-srd.s6h0xkdKf3gecLk6";
-export const CROSSBOW_CRACK_SHOT_EFFECT_ID = "Compendium.pf2e-ranged-combat.effects.hG9i3aOBDZ9Bq9yi";
-
 export class Updates {
     constructor(actor) {
         this.actor = actor;


### PR DESCRIPTION
Apply the Crossbow Ace and Crossbow Crack Shot effects when reloading using the Conjure Bullet macro.

Fixes #69.