### PR TITLE
Fix the Advanced Thrown Weapon System

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.8.3 - 2022-07-15 (Pathfinder 2e 3.12.2)
+- Rewrite the Advanced Thrown Weapon system
+
 ## 2.8.2 - 2022-07-06 (Pathfinder 2e 3.12.2)
 - Apply Crossbow Ace and Crossbow Crack Shot when using Conjure Bullet
 

--- a/README.md
+++ b/README.md
@@ -99,9 +99,9 @@ You can use the <b>Unload Alchemical Crossbow</b> macro to unload the bomb from 
 ### Advanced Thrown Weapon System
 This enhancement to thrown weapons handles the management of which weapons are worn, held, and dropped. A Game Master can enable or disable this system in the module settings <i>(default: disabled)</i>. This feature is currently implemented only for PCs.
 
-With the Advanced Thrown Weapon system, when you attack with a thrown weapon, it will be dropped. If the weapon is in a stack of more than one, then a separate stack will be created as the "dropped" stack, and the main stack will be set to worn (if the weapon must be drawn as a separate action from throwing it). Trying to change the dropped stack to held or worn will instead move one item back to the original stack, and change that stack to held or worn (if not already held).
+With the Advanced Thrown Weapon system, thrown weapons are treated as individual items even if they're part of the same stack. For example, if you have three throwing daggers in a stack which is set as "worn", drawing the weapon will instead create a new stack with one throwing dagger and set that one as held. The other two will remain in the original stack as "worn". This is the same for dropping, sheathing, stowing etc. Empty stacks are then removed.
 
-If the weapon has a reload of 0, then the weapon stack will remain held after the attack, although one item will still be dropped. If the weapon has a returning rune, then the weapon will remain held after the attack and no dropped stack will be created.
+When you attack with a thrown weapon, the weapon will be added to a "dropped" stack, however the original "held" stack will still be kept, even if it's empty. This is so the damage buttons are still usable, but you won't be able to roll another attack until you've drawn or picked up another one.
 
 ## Configuration
 These are the settings available for the module (all world-scope).

--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
     "title": "PF2e Ranged Combat",
     "description": "Utilities for improving ranged combat in Pathfinder 2e.",
     "author": "JDCalvert",
-    "version": "2.8.2",
+    "version": "2.8.3",
     "minimumCoreVersion": "9",
     "compatibleCoreVersion": "9",
     "system": [
@@ -16,7 +16,7 @@
     ],
     "url": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat",
     "manifest": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/releases/latest/download/module.json",
-    "download": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/archive/2.8.2.zip",
+    "download": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/archive/2.8.3.zip",
     "readme": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat",
     "bugs": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/issues",
     "changelog": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/blob/main/CHANGELOG.md",

--- a/scripts/fire-weapon-hook.js
+++ b/scripts/fire-weapon-hook.js
@@ -2,7 +2,7 @@ import { handleWeaponFired as handleAlchemicalCrossbowFired } from "./actions/al
 import { checkLoaded } from "./ammunition-system/fire-weapon-check.js";
 import { fireWeapon } from "./ammunition-system/fire-weapon-handler.js";
 import { handleWeaponFired as crossbowFeatsHandleFired } from "./feats/crossbow-feats.js";
-import { changeCarryType } from "./thrown-weapons/change-carry-type.js";
+import { changeCarryType, changeStowed } from "./thrown-weapons/change-carry-type.js";
 import { checkThrownWeapon } from "./thrown-weapons/throw-weapon-check.js";
 import { handleThrownWeapon } from "./thrown-weapons/throw-weapon-handler.js";
 import { Updates } from "./utils/utils.js";
@@ -18,6 +18,13 @@ Hooks.on(
             "pf2e-ranged-combat",
             "CONFIG.PF2E.Actor.documentClasses.character.prototype.adjustCarryType",
             changeCarryType,
+            "MIXED"
+        );
+
+        libWrapper.register(
+            "pf2e-ranged-combat",
+            "CONFIG.PF2E.Actor.documentClasses.character.prototype.stowOrUnstow",
+            changeStowed,
             "MIXED"
         );
 

--- a/scripts/fire-weapon-hook.js
+++ b/scripts/fire-weapon-hook.js
@@ -21,6 +21,9 @@ Hooks.on(
             "MIXED"
         );
 
+        /** 
+         * Override the function for stowing or unstowing an item
+         */
         libWrapper.register(
             "pf2e-ranged-combat",
             "CONFIG.PF2E.Actor.documentClasses.character.prototype.stowOrUnstow",

--- a/scripts/fire-weapon-hook.js
+++ b/scripts/fire-weapon-hook.js
@@ -88,7 +88,7 @@ Hooks.on(
                 crossbowFeatsHandleFired(weapon, updates);
                 handleAlchemicalCrossbowFired(actor, weapon, updates);
                 fireWeapon(actor, weapon, updates);
-                handleThrownWeapon(weapon, updates);
+                handleThrownWeapon(weapon);
 
                 await updates.handleUpdates();
 

--- a/scripts/thrown-weapons/change-carry-type.js
+++ b/scripts/thrown-weapons/change-carry-type.js
@@ -67,8 +67,8 @@ export async function changeStowed(wrapper, item, container) {
 
     const targetStack = container
         ? groupStacks.find(stack => stack.data.data.equipped.carryType === "stowed" && stack.data.data.containerId === container.id)
-        : groupStacks.find(stack => stack.data.data.equipped.carryType === "worn")
-    
+        : groupStacks.find(stack => stack.data.data.equipped.carryType === "worn");
+
     if (!targetStack) {
         if (item.quantity <= 1) {
             wrapper(item, container);
@@ -191,5 +191,5 @@ function moveBetweenStacks(item, targetStack) {
 function isThrownWeaponUsingAdvancedThrownWeaponSystem(item) {
     return useAdvancedThrownWeaponSystem(item.actor)
         && item.type === "weapon"
-        && Array.from(item.data.data.traits.value).some(trait => trait.startsWith("thrown"));
+        && item.data.data.traits.value.some(trait => trait.startsWith("thrown") || trait === "consumable");
 }

--- a/scripts/thrown-weapons/change-carry-type.js
+++ b/scripts/thrown-weapons/change-carry-type.js
@@ -1,4 +1,4 @@
-import { removeDroppedState } from "./utils.js";
+import { useAdvancedThrownWeaponSystem } from "./utils.js";
 
 /**
  * When we try to change the carry type of an item that represents a dropped version of another item,
@@ -6,56 +6,140 @@ import { removeDroppedState } from "./utils.js";
  * if it puts the item in the character's hands.
  */
 export async function changeCarryType(wrapper, item, carryType, handsHeld, inSlot) {
-    const itemFlags = item.data.flags["pf2e-ranged-combat"];
-    const droppedFrom = itemFlags?.droppedFrom;
-    if (droppedFrom) {
-        const originalItem = item.actor.items.find(item => item.id === droppedFrom.id);
+    // If we're not using the advanced thrown weapon system, or the weapon isn't a thrown weapon,
+    // just call the normal function
+    if (!useAdvancedThrownWeaponSystem(item.actor)
+        || item.type !== "weapon"
+        || !Array.from(item.data.data.traits.value).some(trait => trait.startsWith("thrown"))
+    ) {
+        return wrapper(item, carryType, handsHeld, inSlot);
+    }
 
-        // If we no longer have the item this was dropped from, then remove the flag and call
-        // the function as normal
-        if (!originalItem) {
-            await removeDroppedState(item);
+    // If we're keeping the same carry type (e.g. two-handed to one-handed) then call
+    // the normal function
+    if (carryType === item.data.data.equipped.carryType) {
+        return wrapper(item, carryType, handsHeld, inSlot);
+    }
+
+    // Find the other stacks in this weapon's group
+    const groupIds = item.data.flags["pf2e-ranged-combat"]?.groupIds ?? [item.id];
+    const groupStacks = item.actor.items.filter(i => groupIds.includes(i.id));
+    const groupStackIds = groupStacks.map(stack => stack.id);
+
+    if (item.quantity === 0 && groupStackIds.length > 1) {
+        item.delete();
+        return [];
+    }
+
+    // Find the stack that has the carry type we're trying to set
+    const targetStack = groupStacks.find(stack => stack.data.data.equipped.carryType === carryType);
+
+    // - If there is no target stack then what we do depends on the size of our current stack:
+    //   - If our stack size is one, then we can just call the normal function
+    //   - If our stack size is more than one, then we'll create a new target stack
+    // - If there is an existing target stack, then move one item from one stack to the other
+    //   - If this would leave our original stack empty, then delete it
+    if (!targetStack) {
+        if (item.quantity <= 1) {
             return wrapper(item, carryType, handsHeld, inSlot);
+        } else {
+            createNewStack(item, groupStackIds, groupStacks, carryType, handsHeld, inSlot);
         }
-
+    } else {
         const updates = [];
         const deletes = [];
 
-        // Move one item from this item to the original item
-        updates.push(
-            {
-                _id: originalItem.id,
-                data: {
-                    quantity: originalItem.quantity + 1
-                }
-            }
-        );
-
-        if (item.quantity > 1) {
-            updates.push(
-                {
+        // If we have zero in this stack, just delete it and don't increase the other stack's quantity
+        if (item.quantity === 0) {
+            deletes.push(item.id);
+        } else {
+            // If we have only one in this stack, delete the stack. Otherwise, reduce the quantity by one
+            if (item.quantity === 1) {
+                deletes.push(item.id);
+            } else {
+                updates.push({
                     _id: item.id,
                     data: {
                         quantity: item.quantity - 1
                     }
+                });
+            }
+    
+            // Increase the target's stack quantity by one
+            updates.push(
+                {
+                    _id: targetStack.id,
+                    data: {
+                        quantity: targetStack.quantity + 1
+                    }
                 }
             );
-        } else {
-            deletes.push(item.id);
-        }
+        }        
 
-        // Run the updates and deletions
-        await item.actor.updateEmbeddedDocuments("Item", updates);
-        await item.actor.deleteEmbeddedDocuments("Item", deletes);
-
-        // Finally, if we're trying to move the item into our hands, do that to the
-        // original item instead. Otherwise, we're done.
-        if (carryType === "held") {
-            return wrapper(originalItem, carryType, handsHeld, inSlot);
-        } else {
-            return [];
-        }
+        item.actor.updateEmbeddedDocuments("Item", updates);
+        item.actor.deleteEmbeddedDocuments("Item", deletes);
     }
+    return [];
+}
 
-    return wrapper(item, carryType, handsHeld, inSlot);
+export async function createNewStack(item, groupStackIds, groupStacks, carryType, handsHeld, inSlot) {
+    // Make a copy of this item, with a quantity of zero
+    const itemSource = item.toObject();
+    const [targetStack] = await item.actor.createEmbeddedDocuments(
+        "Item",
+        [
+            {
+                ...itemSource,
+                data: {
+                    ...itemSource.data,
+                    quantity: 0
+                }
+            }
+        ]
+    );
+
+    // If the target stack was created successfully, then we need to update all the other
+    // stacks in the group to add this one.
+    if (targetStack) {
+        groupStacks.push(targetStack);
+        groupStackIds.push(targetStack.id);
+
+        const updates = [];
+
+        // Update the new stack to have a size of one, and the equipped status
+        // that we were trying to update the original stack to
+        updates.push({
+            _id: targetStack.id,
+            data: {
+                equipped: {
+                    carryType,
+                    handsHeld,
+                    inSlot
+                },
+                quantity: 1
+            }
+        });
+
+        // Go through all the stacks in the group and update the group list 
+        for (const stack of groupStacks) {
+            updates.push({
+                _id: stack.id,
+                flags: {
+                    "pf2e-ranged-combat": {
+                        groupIds: groupStackIds
+                    }
+                }
+            });
+        }
+
+        // Finally, reduce the quantity of the original stack by one
+        updates.push({
+            _id: item.id,
+            data: {
+                quantity: item.quantity - 1
+            }
+        });
+
+        await targetStack.actor.updateEmbeddedDocuments("Item", updates);
+    }
 }

--- a/scripts/thrown-weapons/change-carry-type.js
+++ b/scripts/thrown-weapons/change-carry-type.js
@@ -58,6 +58,8 @@ export async function changeStowed(wrapper, item, container) {
 
     const { groupStacks, groupStackIds } = findGroupStacks(item);
 
+    // If we're moving an empty stack, and there is another stack in the group, then just
+    // delete this stack (for example, sheathing a thrown weapon stack when they're all dropped)
     if (item.quantity === 0 && groupStacks.length > 1) {
         item.delete();
         return;

--- a/scripts/thrown-weapons/throw-weapon-check.js
+++ b/scripts/thrown-weapons/throw-weapon-check.js
@@ -1,37 +1,22 @@
 import { showWarning } from "../utils/utils.js";
-import { removeDroppedState } from "./utils.js";
+import { useAdvancedThrownWeaponSystem } from "./utils.js";
 
 /**
  * Prevent rolling an attack with a weapon if the stack size is 0, the weapon is not drawn, or the weapon is a
  * dropped version of another weapon (and that weapon still exists)
  */
 export async function checkThrownWeapon(weapon) {
-    if (!game.settings.get("pf2e-ranged-combat", "advancedThrownWeaponSystemPlayer")) {
+    if (!useAdvancedThrownWeaponSystem(weapon.actor)) {
         return true;
-    }
-
-    const itemFlags = weapon.value.data.flags["pf2e-ranged-combat"];
-    const droppedFrom = itemFlags?.droppedFrom;
-    if (droppedFrom) {
-        const originalWeapon = weapon.actor.items.find(item => item.id === droppedFrom.id);
-        if (originalWeapon) {
-            showWarning(`This weapon represents a dropped version of ${originalWeapon.name} and cannot be used to attack.`);
-            return false;
-        } else {
-            // The original weapon couldn't be found, so remove the droppedFrom flag and the name suffix
-            const updatedWeapon = await removeDroppedState(weapon.value);
-            weapon.value = updatedWeapon;
-            weapon.name = updatedWeapon.name;
-        }
-    }
-
-    if (weapon.value.quantity === 0) {
-        showWarning(`You have no ${weapon.name} left!`);
-        return false;
     }
 
     if (!weapon.isEquipped) {
         showWarning(`${weapon.name} is not equipped!`);
+        return false;
+    }
+
+    if (weapon.value.quantity === 0) {
+        showWarning(`You have no ${weapon.name} left!`);
         return false;
     }
 

--- a/scripts/thrown-weapons/throw-weapon-handler.js
+++ b/scripts/thrown-weapons/throw-weapon-handler.js
@@ -1,120 +1,60 @@
-export function handleThrownWeapon(weapon, updates) {
-    if (!game.settings.get("pf2e-ranged-combat", "advancedThrownWeaponSystemPlayer")) {
+import { createNewStack } from "./change-carry-type.js";
+import { useAdvancedThrownWeaponSystem } from "./utils.js";
+
+export async function handleThrownWeapon(weapon) {
+    if (!useAdvancedThrownWeaponSystem(weapon.actor)) {
         return;
     }
 
-    if (weapon.actor.type !== "character") {
-        return;
-    }
-
-    // If the weapon is a consumable, then it gets destroyed on use.
-    // The system handles reducing the quantity, but set it to worn instead of equipped 
+    // If the weapon is a consumable, then it gets destroyed on use, and we don't need to do anything else
     if (weapon.traits.has("consumable")) {
-        setWeaponToWorn(weapon, updates);
+        return;
     }
 
-    // Thrown weapons aren't destroyed on use. We need to set it to dropped.
-    // If there's more than one in the stack, then we want to set the current stack to worn
-    // and make a new stack for the dropped weapon, or add to an existing dropped stack
-    if (weapon.value.isRanged && Array.from(weapon.traits).some(trait => trait.startsWith("thrown"))) {
-        // Do nothing if the weapon has a returning rune
-        if (weapon.value.data.data.runes.property.includes("returning")) {
-            return;
-        }
-
-        const quantity = weapon.value.quantity;
-
-        // First, see if we have a stack of dropped weapons to add the thrown weapon to
-        const droppedWeapon = getDroppedWeapon(weapon);
-        if (droppedWeapon) {
-            // Remove the thrown weapon from the original stack and, if the weapon must be
-            // drawn to throw another, set the stack to worn
-            reduceQuantity(weapon, updates);
-            if (weapon.value.reload === "-") {
-                setWeaponToWorn(weapon, updates);
-            }
-
-            // Add the thrown weapon to the stack of dropped weapons
-            updates.update(() => {
-                droppedWeapon.update({
-                    "data.quantity": droppedWeapon.quantity + 1
-                });
-            });
-        } else if (quantity === 1) {
-            // We only have one of this weapon, and we don't have a dropped stack,
-            // so just set this set to dropped
-            setWeaponToDropped(weapon, updates);
-        } else {
-            // We don't have a dropped stack, and we have more than one weapon in this stack,
-            // so create a new dropped stack.
-            reduceQuantity(weapon, updates);
-            if (weapon.value.reload === "-") {
-                setWeaponToWorn(weapon, updates);
-            }
-
-            updates.update(async () => {
-                // Make a copy of this item, with a quantity of one, dropped, and a flag to
-                // say that this was created from dropped items in the original stack
-                const weaponSource = weapon.value.toObject();
-                const [ droppedWeapon ] = await weapon.actor.createEmbeddedDocuments(
-                    "Item",
-                    [
-                        {
-                            ...weaponSource,
-                            name: `${weaponSource.name} (Dropped)`,
-                            data: {
-                                ...weaponSource.data,
-                                quantity: 1
-                            },
-                            flags: {
-                                ...weaponSource.flags,
-                                "pf2e-ranged-combat": {
-                                    droppedFrom: {
-                                        id: weapon.id,
-                                        name: weapon.name
-                                    }
-                                }
-                            }
-                        }
-                    ]
-                );
-
-                // Items are automatically added worn, so we need to set it to dropped here
-                droppedWeapon?.update({
-                    "data.equipped.handsHeld": 0,
-                    "data.equipped.carryType": "dropped"
-                });
-            });
-        }
+    // If the weapon isn't thrown, then we don't need to do anything
+    const isThrownWeapon = weapon.value.isRanged && Array.from(weapon.traits).some(trait => trait.startsWith("thrown"));
+    if (!isThrownWeapon) {
+        return;
     }
-}
 
-function getDroppedWeapon(weapon) {
-    return weapon.actor.itemTypes.weapon.find(w => w.data.flags["pf2e-ranged-combat"]?.droppedFrom?.id === weapon.id);
-}
-
-function setWeaponToWorn(weapon, updates) {
-    if (weapon.value.data.data.equipped.carryType === "held") {
-        updates.update(() => weapon.value.update({
-            "data.equipped.handsHeld": 0,
-            "data.equipped.carryType": "worn"
-        }));
+    // If the weapon has a returning rune, then we don't need to do anything
+    if (weapon.value.data.data.runes.property.includes("returning")) {
+        return;
     }
-}
 
-function setWeaponToDropped(weapon, updates) {
-    if (weapon.value.data.data.equipped.carryType === "held") {
-        updates.update(() => weapon.value.update({
-            "data.equipped.handsHeld": 0,
-            "data.equipped.carryType": "dropped"
-        }));
-    }
-}
+    // Thrown weapons aren't destroyed on use, so we need to set it to dropped. However, we can't
+    // roll damage unless the weapon is equipped, so we have to reduce the quantity of this "equipped" stack
+    // and place the thrown weapon into a "dropped" stack
 
-function reduceQuantity(weapon, updates) {
-    if (weapon.value.data.data.quantity > 0) {
-        updates.update(() => weapon.value.update({
-            "data.quantity": weapon.value.data.data.quantity - 1
-        }));
+    // Find the other stacks in this weapon's group
+    const groupIds = weapon.value.data.flags["pf2e-ranged-combat"]?.groupIds ?? [weapon.id];
+    const groupStacks = weapon.actor.items.filter(i => groupIds.includes(i.id));
+    const groupStackIds = groupStacks.map(stack => stack.id);
+
+    // Find the stack that has the carry type we're trying to set
+    const targetStack = groupStacks.find(stack => stack.data.data.equipped.carryType === "dropped");
+
+    if (targetStack) {
+        // We have a dropped stack already
+        weapon.actor.updateEmbeddedDocuments(
+            "Item",
+            [
+                {
+                    _id: weapon.id,
+                    data: {
+                        quantity: weapon.quantity - 1
+                    }
+                },
+                {
+                    _id: targetStack.id,
+                    data: {
+                        quantity: targetStack.quantity + 1
+                    }
+                }
+            ]
+        );
+    } else {
+        const originalWeapon = weapon.actor.items.find(i => i.id === weapon.id);
+        createNewStack(originalWeapon, groupStackIds, groupStacks, "dropped", 0, false);
     }
 }

--- a/scripts/thrown-weapons/throw-weapon-handler.js
+++ b/scripts/thrown-weapons/throw-weapon-handler.js
@@ -1,4 +1,4 @@
-import { createNewStack } from "./change-carry-type.js";
+import { createNewStack, findGroupStacks } from "./change-carry-type.js";
 import { useAdvancedThrownWeaponSystem } from "./utils.js";
 
 export async function handleThrownWeapon(weapon) {
@@ -27,9 +27,7 @@ export async function handleThrownWeapon(weapon) {
     // and place the thrown weapon into a "dropped" stack
 
     // Find the other stacks in this weapon's group
-    const groupIds = weapon.value.data.flags["pf2e-ranged-combat"]?.groupIds ?? [weapon.id];
-    const groupStacks = weapon.actor.items.filter(i => groupIds.includes(i.id));
-    const groupStackIds = groupStacks.map(stack => stack.id);
+    const { groupStacks, groupStackIds } = findGroupStacks(weapon.value);
 
     // Find the stack that has the carry type we're trying to set
     const targetStack = groupStacks.find(stack => stack.data.data.equipped.carryType === "dropped");

--- a/scripts/thrown-weapons/throw-weapon-handler.js
+++ b/scripts/thrown-weapons/throw-weapon-handler.js
@@ -6,11 +6,6 @@ export async function handleThrownWeapon(weapon) {
         return;
     }
 
-    // If the weapon is a consumable, then it gets destroyed on use, and we don't need to do anything else
-    if (weapon.traits.has("consumable")) {
-        return;
-    }
-
     // If the weapon isn't thrown, then we don't need to do anything
     const isThrownWeapon = weapon.value.isRanged && Array.from(weapon.traits).some(trait => trait.startsWith("thrown"));
     if (!isThrownWeapon) {

--- a/scripts/thrown-weapons/utils.js
+++ b/scripts/thrown-weapons/utils.js
@@ -1,5 +1,3 @@
-import { getFlags } from "../utils/utils.js";
-
 /**
  * For the given actor type, check if the advanced thrown weapon system is enabled
  */
@@ -11,43 +9,4 @@ export function useAdvancedThrownWeaponSystem(actor) {
     } else {
         return false;
     }
-}
-
-export function reduceQuantity(weapon, updates) {
-    if (weapon.value.quantity > 0) {
-        updates.update(() => weapon.value.update({
-            "data.quantity": weapon.value.quantity - 1
-        }));
-    }
-}
-
-/**
- * Remove the droppedFrom flag, and update the name to remove the "Updated" suffix
- */
-export async function removeDroppedState(item) {
-    const flags = item.data.flags["pf2e-ranged-combat"];
-    const droppedFromName = flags.droppedFrom.name;
-    delete flags.droppedFrom;
-    return await item.update(
-        {
-            name: droppedFromName,
-            "flags.pf2e-ranged-combat": flags
-        }
-    );
-}
-
-/**
- * Find the stack for this item with the specified carry type
- */
-export function getStack(item, carryType) {
-    const stackId = getFlags(item)?.stacks?.[carryType]?.id;
-    if (stackId) {
-        return item.actor.items.find(i => i.id === stackId);
-    }
-    return null;
-}
-
-export function getDroppedWeapon(weapon) {
-    const droppedWeaponId = weapon.data.flags["pf2e-ranged-combat"]?.droppedId;
-    return weapon.actor.itemTypes.weapon.find(w => w.id === droppedWeaponId);
 }

--- a/scripts/thrown-weapons/utils.js
+++ b/scripts/thrown-weapons/utils.js
@@ -1,5 +1,28 @@
+import { getFlags } from "../utils/utils.js";
+
 /**
- * Remove the droppedFrom flag, and update the name to remove the " Updated" suffix
+ * For the given actor type, check if the advanced thrown weapon system is enabled
+ */
+export function useAdvancedThrownWeaponSystem(actor) {
+    if (actor.type === "character") {
+        return game.settings.get("pf2e-ranged-combat", "advancedThrownWeaponSystemPlayer");
+    } else if (actor.type === "npc") {
+        return false; // Placeholder for NPC advanced thrown weapon system
+    } else {
+        return false;
+    }
+}
+
+export function reduceQuantity(weapon, updates) {
+    if (weapon.value.quantity > 0) {
+        updates.update(() => weapon.value.update({
+            "data.quantity": weapon.value.quantity - 1
+        }));
+    }
+}
+
+/**
+ * Remove the droppedFrom flag, and update the name to remove the "Updated" suffix
  */
 export async function removeDroppedState(item) {
     const flags = item.data.flags["pf2e-ranged-combat"];
@@ -10,5 +33,21 @@ export async function removeDroppedState(item) {
             name: droppedFromName,
             "flags.pf2e-ranged-combat": flags
         }
-    )
+    );
+}
+
+/**
+ * Find the stack for this item with the specified carry type
+ */
+export function getStack(item, carryType) {
+    const stackId = getFlags(item)?.stacks?.[carryType]?.id;
+    if (stackId) {
+        return item.actor.items.find(i => i.id === stackId);
+    }
+    return null;
+}
+
+export function getDroppedWeapon(weapon) {
+    const droppedWeaponId = weapon.data.flags["pf2e-ranged-combat"]?.droppedId;
+    return weapon.actor.itemTypes.weapon.find(w => w.id === droppedWeaponId);
 }

--- a/scripts/utils/migrations/migration-001-multiple-ammunitions.js
+++ b/scripts/utils/migrations/migration-001-multiple-ammunitions.js
@@ -6,7 +6,7 @@ export class Migration001MultipleAmmunitions {
     version = 1;
 
     async runMigration() {
-        console.log("PF2e Ranged Combat - Running Migration 1: Multiple Ammunition Update");
+        console.info("PF2e Ranged Combat - Running Migration 1: Multiple Ammunition Update");
 
         const actors = game.actors.contents;
 

--- a/scripts/utils/migrations/migration-002-thrown-weapon-groups.js
+++ b/scripts/utils/migrations/migration-002-thrown-weapon-groups.js
@@ -1,0 +1,81 @@
+import { useAdvancedThrownWeaponSystem } from "../../thrown-weapons/utils.js";
+import { getFlags } from "../utils.js";
+import { getWeapons } from "../weapon-utils.js";
+
+export class Migration002ThrownWeaponGroups {
+    version = 2;
+
+    async runMigration() {
+        console.info("PF2e Ranged Combat - Running Migration 1: Multiple Ammunition Update");
+
+        const actors = game.actors.contents;
+
+        for (const actor of actors) {
+            if (!useAdvancedThrownWeaponSystem(actor)) {
+                continue;
+            }
+
+            const updates = [];
+
+            const weapons = actor.itemTypes.weapon;
+
+            for (const weapon of weapons) {
+                weapon.unsetFlag("pf2e-ranged-combat", "groupIds");
+
+                const flags = getFlags(weapon)?.droppedFrom;
+                if (!flags) {
+                    continue;
+                }
+
+                const droppedFrom = flags.droppedFrom;
+                if (droppedFrom) {
+
+                    // Remove the droppedFrom flag and reset the name
+                    updates.push(
+                        {
+                            _id: weapon.id,
+                            name: droppedFrom.name,
+                            flags: {
+                                "pf2e-ranged-combat": {
+                                    "-=droppedFrom": null
+                                }
+                            }
+                        }
+                    );
+
+                    // Look for the weapon this was dropped from
+                    const originalWeapon = weapons.find(w => w.id === droppedFrom.id);
+                    if (originalWeapon) {
+                        const groupIds = [originalWeapon.id, weapon.id];
+
+                        // Update the original weapon to set the group
+                        updates.push(
+                            {
+                                _id: originalWeapon.id,
+                                flags: {
+                                    "pf2e-ranged-combat": {
+                                        groupIds
+                                    }
+                                }
+                            }
+                        );
+
+                        // Update the current weapon to set the group
+                        updates.push(
+                            {
+                                _id: weapon.id,
+                                flags: {
+                                    "pf2e-ranged-combat": {
+                                        groupIds
+                                    }
+                                }
+                            }
+                        );
+                    }
+                }
+            }
+
+            actor.updateEmbeddedDocuments("Item", updates);
+        }
+    }
+}

--- a/scripts/utils/migrations/migration-002-thrown-weapon-groups.js
+++ b/scripts/utils/migrations/migration-002-thrown-weapon-groups.js
@@ -1,12 +1,11 @@
 import { useAdvancedThrownWeaponSystem } from "../../thrown-weapons/utils.js";
 import { getFlags } from "../utils.js";
-import { getWeapons } from "../weapon-utils.js";
 
 export class Migration002ThrownWeaponGroups {
     version = 2;
 
     async runMigration() {
-        console.info("PF2e Ranged Combat - Running Migration 1: Multiple Ammunition Update");
+        console.info("PF2e Ranged Combat - Running Migration 2: Thrown Weapon Groups");
 
         const actors = game.actors.contents;
 
@@ -20,58 +19,52 @@ export class Migration002ThrownWeaponGroups {
             const weapons = actor.itemTypes.weapon;
 
             for (const weapon of weapons) {
-                weapon.unsetFlag("pf2e-ranged-combat", "groupIds");
-
-                const flags = getFlags(weapon)?.droppedFrom;
-                if (!flags) {
+                const droppedFrom = getFlags(weapon)?.droppedFrom;
+                if (!droppedFrom) {
                     continue;
                 }
 
-                const droppedFrom = flags.droppedFrom;
-                if (droppedFrom) {
+                // Remove the droppedFrom flag and reset the name
+                updates.push(
+                    {
+                        _id: weapon.id,
+                        name: droppedFrom.name,
+                        flags: {
+                            "pf2e-ranged-combat": {
+                                "-=droppedFrom": null
+                            }
+                        }
+                    }
+                );
 
-                    // Remove the droppedFrom flag and reset the name
+                // Look for the weapon this was dropped from
+                const originalWeapon = weapons.find(w => w.id === droppedFrom.id);
+                if (originalWeapon) {
+                    const groupIds = [originalWeapon.id, weapon.id];
+
+                    // Update the original weapon to set the group
                     updates.push(
                         {
-                            _id: weapon.id,
-                            name: droppedFrom.name,
+                            _id: originalWeapon.id,
                             flags: {
                                 "pf2e-ranged-combat": {
-                                    "-=droppedFrom": null
+                                    groupIds
                                 }
                             }
                         }
                     );
 
-                    // Look for the weapon this was dropped from
-                    const originalWeapon = weapons.find(w => w.id === droppedFrom.id);
-                    if (originalWeapon) {
-                        const groupIds = [originalWeapon.id, weapon.id];
-
-                        // Update the original weapon to set the group
-                        updates.push(
-                            {
-                                _id: originalWeapon.id,
-                                flags: {
-                                    "pf2e-ranged-combat": {
-                                        groupIds
-                                    }
+                    // Update the current weapon to set the group
+                    updates.push(
+                        {
+                            _id: weapon.id,
+                            flags: {
+                                "pf2e-ranged-combat": {
+                                    groupIds
                                 }
                             }
-                        );
-
-                        // Update the current weapon to set the group
-                        updates.push(
-                            {
-                                _id: weapon.id,
-                                flags: {
-                                    "pf2e-ranged-combat": {
-                                        groupIds
-                                    }
-                                }
-                            }
-                        );
-                    }
+                        }
+                    );
                 }
             }
 

--- a/scripts/utils/migrations/migration.js
+++ b/scripts/utils/migrations/migration.js
@@ -1,20 +1,22 @@
 import { Migration001MultipleAmmunitions } from "./migration-001-multiple-ammunitions.js";
+import { Migration002ThrownWeaponGroups } from "./migration-002-thrown-weapon-groups.js";
 
 const MIGRATIONS = [
-    new Migration001MultipleAmmunitions()
+    new Migration001MultipleAmmunitions(),
+    new Migration002ThrownWeaponGroups()
 ];
-const LATEST_SCHEMA_VERSION = 1;
+const LATEST_SCHEMA_VERSION = 2;
 
 export async function runMigrations() {
     const currentSchemaVersion = game.settings.get("pf2e-ranged-combat", "schemaVersion") || 0;
 
-    if (currentSchemaVersion === LATEST_SCHEMA_VERSION) {
+    if (currentSchemaVersion >= LATEST_SCHEMA_VERSION) {
         return;
     }
 
     for (const migration of MIGRATIONS) {
         if (migration.version > currentSchemaVersion) {
-            migration.runMigration();
+            await migration.runMigration();
         }
     }
 


### PR DESCRIPTION
The thrown weapon system in its current state does not function correctly. Upon rolling the attack roll for a thrown weapon Strike, the weapon is set to "worn", which removes the damage button and renders the attack roll's chat card's damag buttons non-functional.

Here, I've changed the system to always treat thrown weapons individually. Drawing from a stack of throwing knives will create a new stack containing one of them, and the new stack is set as held. The others are still "worn". Throwing the weapon will make a "dropped" stack, but the "held" stack is kept so the damage buttons are usable.

Fixes #67.