### PR TITLE
Return early if moving an item into itself

### DIFF
--- a/scripts/thrown-weapons/change-carry-type.js
+++ b/scripts/thrown-weapons/change-carry-type.js
@@ -157,6 +157,10 @@ function moveBetweenStacks(item, targetStack) {
     const updates = [];
     const deletes = [];
 
+    // Return early if we're moving an item into itself
+    if (item.id === targetStack.id) {
+        return
+    }
     // If we have zero in this stack, just delete it and don't increase the other stack's quantity
     if (item.quantity === 0) {
         deletes.push(item.id);


### PR DESCRIPTION
Bit of a blunt instrument. See investigation in https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/issues/77, but this is doing nothing to address the root cause.