### PR TITLE
Fix issues with reloading magazines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.1 - 2022-09-30 (Pathfinder 2e 4.1.3)
+- Fix issues reloading magazines
+
 ## 3.1.0 - 2022-09-22 (Pathfinder 2e 4.1.2)
 - Add macro to switch weapon ammunition
 

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
     "id": "pf2e-ranged-combat",
     "title": "PF2e Ranged Combat",
     "description": "Utilities for improving ranged combat in Pathfinder 2e.",
-    "version": "3.1.0",
+    "version": "3.1.1",
     "authors": [
         {
             "name": "JDCalvert"
@@ -28,7 +28,7 @@
     },
     "url": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat",
     "manifest": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/releases/latest/download/module.json",
-    "download": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/archive/3.1.0.zip",
+    "download": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/archive/3.1.1.zip",
     "readme": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat",
     "bugs": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/issues",
     "changelog": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/blob/main/CHANGELOG.md",

--- a/scripts/ammunition-system/actions/consolidate-ammunition.js
+++ b/scripts/ammunition-system/actions/consolidate-ammunition.js
@@ -7,7 +7,7 @@ export async function consolidateRepeatingWeaponAmmunition() {
     }
 
     // Find all the repeating ammunition stacks
-    const ammunitionStacks = actor.itemTypes.consumable.filter(consumable => consumable.isAmmunition && consumable.charges.max > 1);
+    const ammunitionStacks = actor.itemTypes.consumable.filter(consumable => consumable.isAmmunition && consumable.system.charges.max > 1);
     const ammunitionStacksBySourceId = ammunitionStacks.reduce(
         function(map, stack) {
             const mapEntry = map[stack.sourceId];
@@ -31,7 +31,7 @@ export async function consolidateRepeatingWeaponAmmunition() {
         const stackEntry = ammunitionStacksBySourceId[sourceId];
         const stacks = stackEntry.stacks;
 
-        const maxChargesPerItem = stacks[0].charges.max;
+        const maxChargesPerItem = stacks[0].system.charges.max;
 
         // Work out if we need to consolidate:
         // - We have one stack with zero quantity
@@ -41,8 +41,8 @@ export async function consolidateRepeatingWeaponAmmunition() {
         // - AND
         //   - We have no other stacks
         const haveEmptyStack = stacks.some(stack => stack.quantity === 0);
-        const haveFullStack = stacks.some(stack => stack.quantity > 0 && stack.charges.current === stack.charges.max);
-        const haveNonFullStack = stacks.some(stack => stack.quantity === 1 && stack.charges.current !== stack.charges.max);
+        const haveFullStack = stacks.some(stack => stack.quantity > 0 && stack.system.charges.value === stack.system.charges.max);
+        const haveNonFullStack = stacks.some(stack => stack.quantity === 1 && stack.system.charges.value !== stack.system.charges.max);
         if ((haveEmptyStack && stacks.length === 1) || stacks.length === haveFullStack + haveNonFullStack) {
             continue;
         }
@@ -57,8 +57,8 @@ export async function consolidateRepeatingWeaponAmmunition() {
             const indexNow = index;
             updates.update(async () => {
                 await stacks[indexNow].update({
-                    "data.quantity": quantityFullCharges,
-                    "data.charges.value": maxChargesPerItem
+                    "system.quantity": quantityFullCharges,
+                    "system.charges.value": maxChargesPerItem
                 });
             });
             index++;
@@ -75,8 +75,8 @@ export async function consolidateRepeatingWeaponAmmunition() {
                 const indexNow = index;
                 updates.update(async () => {
                     await stacks[indexNow].update({
-                        "data.quantity": 1,
-                        "data.charges.value": remainingCharges
+                        "system.quantity": 1,
+                        "system.charges.value": remainingCharges
                     });
                 });
                 index++;
@@ -105,5 +105,5 @@ export async function consolidateRepeatingWeaponAmmunition() {
 }
 
 function getTotalChargesForStack(stack) {
-    return stack.quantity > 0 ? stack.charges.current + (stack.quantity - 1) * stack.charges.max : 0;
+    return stack.quantity > 0 ? stack.system.charges.value + (stack.quantity - 1) * stack.system.charges.max : 0;
 }

--- a/scripts/ammunition-system/actions/reload-magazine.js
+++ b/scripts/ammunition-system/actions/reload-magazine.js
@@ -69,7 +69,7 @@ export async function reloadMagazine() {
             // The current magazine is full, and the selected ammunition is the same
             showWarning(`${weapon.name} is already loaded with a full magazine.`);
             return;
-        } else if (magazineRemaining === ammo.charges.current && magazineSourceId === selectedAmmunitionSourceId) {
+        } else if (magazineRemaining === ammo.system.charges.value && magazineSourceId === selectedAmmunitionSourceId) {
             // The current magazine is the same, and has the same remaining ammunition, as the new one
             showWarning(`${weapon.name}'s current magazine is already loaded with as much ammunition as ${ammo.name}`);
             return;
@@ -87,15 +87,15 @@ export async function reloadMagazine() {
     magazineLoadedEffectSource.flags["pf2e-ranged-combat"] = {
         ...magazineLoadedEffectSource.flags["pf2e-ranged-combat"],
         name: `${magazineLoadedEffectSource.name} (${ammo.name})`,
-        capacity: ammo.charges.max,
-        remaining: ammo.charges.current,
+        capacity: ammo.system.charges.max,
+        remaining: ammo.system.charges.value,
         ammunitionName: ammo.name,
         ammunitionImg: ammo.img,
         ammunitionItemId: ammo.id,
         ammunitionSourceId: ammo.sourceId
     };
 
-    magazineLoadedEffectSource.name = `${magazineLoadedEffectSource.name} (${ammo.name}) (${ammo.charges.current}/${ammo.charges.max})`;
+    magazineLoadedEffectSource.name = `${magazineLoadedEffectSource.name} (${ammo.name}) (${ammo.system.charges.value}/${ammo.system.charges.max})`;
 
     updates.add(magazineLoadedEffectSource);
 
@@ -106,15 +106,15 @@ export async function reloadMagazine() {
     // Remove that magazine from the stack
     updates.update(async () => {
         await ammo.update({
-            "data.quantity": ammo.quantity - 1,
-            "data.charges.value": ammo.charges.max,
+            "system.quantity": ammo.quantity - 1,
+            "system.charges.value": ammo.system.charges.max,
         });
     });
 
     await postInChat(
         actor,
         RELOAD_MAGAZINE_IMG,
-        `${token.name} loads their ${weapon.name} with ${ammo.name} (${ammo.charges.current}/${ammo.charges.max}).`,
+        `${token.name} loads their ${weapon.name} with ${ammo.name} (${ammo.system.charges.value}/${ammo.system.charges.max}).`,
         "Interact",
         String(numActions)
     );


### PR DESCRIPTION
A data structure change as part of Foundry v10/Pathfinder 2e v4 meant that the way the module interacted with magazine charges. This update fixes those issues.

Resolves #85.