### PR TITLE
Enable multiple hunted preys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## Unreleased
+### Features
+- Allow characters with Double Prey and Triple Threat to select multiple hunted preys
+
 ### Fixes
 - Migrate predicates to new structure
 - Fix several instances of manually-assigned effects not working

--- a/scripts/hunt-prey/hunt-prey.js
+++ b/scripts/hunt-prey/hunt-prey.js
@@ -1,8 +1,13 @@
 import { handleHuntPrey } from "../feats/crossbow-feats.js";
-import { getControlledActorAndToken, getEffectFromActor, getItem, getItemFromActor, getTarget, postActionInChat, postInChat, setEffectTarget, showWarning, Updates } from "../utils/utils.js";
+import { getControlledActorAndToken, getItem, getItemFromActor, postActionInChat, postInChat, showWarning, Updates } from "../utils/utils.js";
 
 export const HUNT_PREY_ACTION_ID = "Compendium.pf2e.actionspf2e.JYi4MnsdFu618hPm";
 export const HUNTED_PREY_EFFECT_ID = "Compendium.pf2e-ranged-combat.effects.rdLADYwOByj8AZ7r";
+
+export const DOUBLE_PREY_FEAT_ID = "Compendium.pf2e.feats-srd.pbD4lfAPkK1NNag0";
+export const TRIPLE_THREAT_FEAT_ID = "Compendium.pf2e.feats-srd.EHorYedQ8r05qAtk";
+export const SHARED_PREY_FEAT_ID = "Compendium.pf2e.feats-srd.Aqhsx5duEpBgaPB0";
+
 export const HUNT_PREY_IMG = "systems/pf2e/icons/features/classes/hunt-prey.webp";
 
 export async function huntPrey() {
@@ -11,51 +16,72 @@ export async function huntPrey() {
         return;
     }
 
-    const updates = new Updates(actor);
-
     const huntPreyAction = getItemFromActor(actor, HUNT_PREY_ACTION_ID);
     if (!huntPreyAction) {
         showWarning(`${token.name} does not have the Hunt Prey action.`);
         return;
     }
 
-    const target = getTarget();
-    if (!target) {
+    const hasDoublePrey = !!getItemFromActor(actor, DOUBLE_PREY_FEAT_ID);
+    const hasSharedPrey = !!getItemFromActor(actor, SHARED_PREY_FEAT_ID);
+    const hasTripleThreat = !!getItemFromActor(actor, TRIPLE_THREAT_FEAT_ID);
+
+    const maxTargets = hasTripleThreat
+        ? { num: 3, word: "three" }
+        : hasDoublePrey
+            ? { num: 2, word: "two" }
+            : { num: 1, word: "one" };
+
+    const targets = getTargets(maxTargets);
+    if (!targets.length) {
         return;
     }
 
-    // Check if the target is already hunted prey
-    if (getEffectFromActor(actor, HUNTED_PREY_EFFECT_ID, target.id)) {
-        showWarning(`${target.name} is already ${token.name}'s hunted prey.`);
-        return;
-    }
+    const updates = new Updates(actor);
 
     /**
      * HUNT PREY ACTION AND EFFECT
      */
     {
+        const remainingTargets = maxTargets.num - targets.length;
+        const remainingTargetsText = remainingTargets === 2
+            ? ", and can share the effect with two allies"
+            : remainingTargets === 1 && hasSharedPrey
+                ? ", and can share the effect with one ally"
+                : "";
+
         await postActionInChat(huntPreyAction);
         await postInChat(
             actor,
             HUNT_PREY_IMG,
-            `${token.name} makes ${target.name} their hunted prey.`,
+            targets.length === 3
+                ? `${token.name} makes ${targets[0].name}, ${targets[1].name}, and ${targets[2].name} their hunted prey.`
+                : targets.length === 2
+                    ? `${token.name} makes ${targets[0].name} and ${targets[1].name} their hunted prey${remainingTargetsText}.`
+                    : `${token.name} makes ${targets[0].name} their hunted prey${remainingTargetsText}.`
+            ,
             huntPreyAction.name,
             1
         );
 
         // Remove any existing hunted prey effects
-        const existing = getItemFromActor(actor, HUNTED_PREY_EFFECT_ID);
-        if (existing) {
-            updates.delete(existing);
+        const existingHuntedPreyEffect = getItemFromActor(actor, HUNTED_PREY_EFFECT_ID);
+        if (existingHuntedPreyEffect) {
+            updates.delete(existingHuntedPreyEffect);
         }
 
         // Add the new effect
         const huntedPreyEffectSource = await getItem(HUNTED_PREY_EFFECT_ID);
-        setEffectTarget(huntedPreyEffectSource, target);
+        huntedPreyEffectSource.flags = {
+            ...huntedPreyEffectSource.flags,
+            "pf2e-ranged-combat": {
+                "targetIds": targets.map(target => target.id)
+            }
+        }
         updates.create(huntedPreyEffectSource);
 
         // Update the hunted prey flag to true
-        const rules = huntPreyAction.toObject().system.rules;
+        const rules = huntPreyAction.system.rules;
         const rule = rules.find(r => r.key === "RollOption" && r.option === "hunted-prey" && !r.value);
         if (rule) {
             rule.value = true;
@@ -66,4 +92,19 @@ export async function huntPrey() {
     await handleHuntPrey(actor, updates);
 
     updates.handleUpdates();
+}
+
+function getTargets(maxTargets) {
+    const targetTokenIds = game.user.targets.ids;
+    const targetTokens = canvas.tokens.placeables.filter(token => targetTokenIds.includes(token.id));
+
+    if (!targetTokens.length) {
+        showWarning("No target selected.");
+        return [];
+    } else if (targetTokens.length > maxTargets.num) {
+        showWarning(`You may only have ${maxTargets.word} hunted prey.`);
+        return [];
+    } else {
+        return targetTokens;
+    }
 }

--- a/scripts/hunt-prey/hunted-prey-hook.js
+++ b/scripts/hunt-prey/hunted-prey-hook.js
@@ -30,19 +30,19 @@ function setHuntedPrey() {
             continue;
         }
 
-        const huntedPreyId = getFlag(huntedPreyEffect, "targetId");
-        if (!huntedPreyId) {
+        const huntedPreyIds = getFlag(huntedPreyEffect, "targetIds");
+        if (!huntedPreyIds?.length) {
             continue;
         }
 
-        const isHuntedPrey = targetedIds.length === 1 && targetedIds.includes(huntedPreyId);
+        const areAllTargetsHuntedPrey = !!targetedIds.length && targetedIds.every(targetedId => huntedPreyIds.includes(targetedId));
 
         const huntPreyAction = getItemFromActor(actor, HUNT_PREY_ACTION_ID);
         if (huntPreyAction) {
-            const rules = huntPreyAction.toObject().system.rules;
-            const rule = rules.find(r => r.key === "RollOption" && r.option === "hunted-prey" && r.value !== isHuntedPrey);
-            if (rule && rule.value != isHuntedPrey) {
-                rule.value = isHuntedPrey;
+            const rules = huntPreyAction.system.rules;
+            const rule = rules.find(r => r.key === "RollOption" && r.option === "hunted-prey" && r.value !== areAllTargetsHuntedPrey);
+            if (rule && rule.value != areAllTargetsHuntedPrey) {
+                rule.value = areAllTargetsHuntedPrey;
                 huntPreyAction.update({ "system.rules": rules });
             }
         }

--- a/scripts/utils/migrations/migration-003-hunted-prey-array.js
+++ b/scripts/utils/migrations/migration-003-hunted-prey-array.js
@@ -1,0 +1,33 @@
+import { HUNTED_PREY_EFFECT_ID } from "../../hunt-prey/hunt-prey.js";
+import { useAdvancedThrownWeaponSystem } from "../../thrown-weapons/utils.js";
+import { getEffectFromActor, getFlags } from "../utils.js";
+
+export class Migration003HuntedPreyArray {
+    version = 3;
+
+    async runMigration() {
+        console.info("PF2e Ranged Combat - Running Migration 3: Hunted Prey Array");
+
+        const actors = game.actors.contents;
+
+        for (const actor of actors) {
+            const huntedPreyEffect = getEffectFromActor(actor, HUNTED_PREY_EFFECT_ID);
+            const flags = getFlags(huntedPreyEffect);
+
+            if (!flags.targetId) {
+                continue;
+            }
+
+            huntedPreyEffect.update(
+                {
+                    flags: {
+                        "pf2e-ranged-combat": {
+                            "-=targetId": null,
+                            targetIds: [flags.targetId]
+                        }
+                    }
+                }
+            );
+        }
+    }
+}

--- a/scripts/utils/migrations/migration-003-hunted-prey-array.js
+++ b/scripts/utils/migrations/migration-003-hunted-prey-array.js
@@ -1,6 +1,5 @@
 import { HUNTED_PREY_EFFECT_ID } from "../../hunt-prey/hunt-prey.js";
-import { useAdvancedThrownWeaponSystem } from "../../thrown-weapons/utils.js";
-import { getEffectFromActor, getFlags } from "../utils.js";
+import { getFlags, getItemFromActor } from "../utils.js";
 
 export class Migration003HuntedPreyArray {
     version = 3;
@@ -11,9 +10,12 @@ export class Migration003HuntedPreyArray {
         const actors = game.actors.contents;
 
         for (const actor of actors) {
-            const huntedPreyEffect = getEffectFromActor(actor, HUNTED_PREY_EFFECT_ID);
-            const flags = getFlags(huntedPreyEffect);
+            const huntedPreyEffect = getItemFromActor(actor, HUNTED_PREY_EFFECT_ID);
+            if (!huntedPreyEffect) {
+                continue;
+            }
 
+            const flags = getFlags(huntedPreyEffect);
             if (!flags.targetId) {
                 continue;
             }

--- a/scripts/utils/migrations/migration.js
+++ b/scripts/utils/migrations/migration.js
@@ -1,11 +1,13 @@
 import { Migration001MultipleAmmunitions } from "./migration-001-multiple-ammunitions.js";
 import { Migration002ThrownWeaponGroups } from "./migration-002-thrown-weapon-groups.js";
+import { Migration003HuntedPreyArray } from "./migration-003-hunted-prey-array.js";
 
 const MIGRATIONS = [
     new Migration001MultipleAmmunitions(),
-    new Migration002ThrownWeaponGroups()
+    new Migration002ThrownWeaponGroups(),
+    new Migration003HuntedPreyArray()
 ];
-const LATEST_SCHEMA_VERSION = 2;
+const LATEST_SCHEMA_VERSION = 3;
 
 export async function runMigrations() {
     const currentSchemaVersion = game.settings.get("pf2e-ranged-combat", "schemaVersion") || 0;

--- a/scripts/utils/migrations/migration.js
+++ b/scripts/utils/migrations/migration.js
@@ -10,6 +10,10 @@ const MIGRATIONS = [
 const LATEST_SCHEMA_VERSION = 3;
 
 export async function runMigrations() {
+    if (!game.user.isGM) {
+        return;
+    }
+
     const currentSchemaVersion = game.settings.get("pf2e-ranged-combat", "schemaVersion") || 0;
 
     if (currentSchemaVersion >= LATEST_SCHEMA_VERSION) {

--- a/scripts/utils/utils.js
+++ b/scripts/utils/utils.js
@@ -99,23 +99,6 @@ export function getControlledActorAndToken() {
 }
 
 /**
- * Find exactly one targeted token
- */
-export function getTarget(notifyNoToken = true) {
-    const targetTokenIds = game.user.targets.ids;
-    const targetTokens = canvas.tokens.placeables.filter(token => targetTokenIds.includes(token.id));
-    if (!targetTokens.length) {
-        if (notifyNoToken) showWarning("No target selected.");
-    } else if (targetTokens.length > 1) {
-        if (notifyNoToken) showWarning("You must have only one target selected.");
-    } else {
-        return targetTokens[0];
-    }
-
-    return null;
-}
-
-/**
  * Find a non-stowed item on the actor, preferably matching the passed item ID, but fall back on an item
  * with the same source ID if one cannot be found
  */


### PR DESCRIPTION
For characters who have the Double Prey and Triple Threat feats, allow multiple targets to be selected when using the Hunt Prey macro. If the character has the Shared Prey feat, the chat message will also serve as a reminder that the effects can be shared, and with how many other characters.