### PR TITLE
Prompt ammunition selection when reloading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 ### Features
 - Allow characters with Double Prey and Triple Threat to select multiple hunted preys
+- Prompt to select ammunition when trying to reload a weapon with no or empty ammunition
 
 ### Fixes
 - Migrate predicates to new structure

--- a/scripts/ammunition-system/actions/reload-magazine.js
+++ b/scripts/ammunition-system/actions/reload-magazine.js
@@ -131,7 +131,7 @@ async function getAmmunition(weapon, updates) {
         return await selectAmmunition(
             weapon,
             updates,
-            `You have no ammunition compatible with your ${weapon.name}.`,
+            `You have no equipped ammunition compatible with your ${weapon.name}.`,
             `You have no ammunition selected for your ${weapon.name}.</p><p>Select the ammunition to load.`,
             false,
             false

--- a/scripts/ammunition-system/actions/reload.js
+++ b/scripts/ammunition-system/actions/reload.js
@@ -269,7 +269,7 @@ async function getAmmunition(weapon, updates) {
         return await selectAmmunition(
             weapon,
             updates,
-            `You have no ammunition compatible with ${weapon.name}.`,
+            `You have no equipped ammunition compatible with ${weapon.name}.`,
             `You have no ammunition selected for your ${weapon.name}.</p><p>Select the ammunition to load.`,
             false,
             false

--- a/scripts/ammunition-system/actions/switch-ammunition.js
+++ b/scripts/ammunition-system/actions/switch-ammunition.js
@@ -18,7 +18,7 @@ export async function switchAmmunition() {
     await selectAmmunition(
         weapon,
         updates,
-        "You have no ammunition equipped.",
+        `You have equipped ammunition compatible with your ${weapon.name}.`,
         "Select the ammunition to switch to.",
         true,
         true

--- a/scripts/hunt-prey/hunt-prey.js
+++ b/scripts/hunt-prey/hunt-prey.js
@@ -72,12 +72,13 @@ export async function huntPrey() {
 
         // Add the new effect
         const huntedPreyEffectSource = await getItem(HUNTED_PREY_EFFECT_ID);
+        huntedPreyEffectSource.name = `${huntedPreyEffectSource.name} (${targets.map(target => target.name).join(", ")})`;
         huntedPreyEffectSource.flags = {
             ...huntedPreyEffectSource.flags,
             "pf2e-ranged-combat": {
                 "targetIds": targets.map(target => target.id)
             }
-        }
+        };
         updates.create(huntedPreyEffectSource);
 
         // Update the hunted prey flag to true

--- a/scripts/utils/item-select-dialog.js
+++ b/scripts/utils/item-select-dialog.js
@@ -23,7 +23,7 @@ export class ItemSelectDialog extends Dialog {
     static async getItemWithOptions(title, header, items, options) {    
         let content = `
             <div class="item-buttons" style="min-width: 200px; max-width: max-content; justify-items: center; margin: auto;">
-            <p style="max-width: 200px;">${header}</p>
+            <p style="width: 200px; min-width: 100%">${header}</p>
         `;
 
         for (const itemCategory of items.keys()) {
@@ -80,7 +80,7 @@ export class ItemSelectDialog extends Dialog {
         }
 
         let result = await itemSelectDialog.getItemId();
-        if (!result) {
+        if (!result?.itemId) {
             return null;
         }
 

--- a/scripts/utils/item-select-dialog.js
+++ b/scripts/utils/item-select-dialog.js
@@ -20,7 +20,7 @@ export class ItemSelectDialog extends Dialog {
         return result?.item;
     }
 
-    static async getItemWithOptions(title, header, items, options) {    
+    static async getItemWithOptions(title, header, items, options) {
         let content = `
             <div class="item-buttons" style="min-width: 200px; max-width: max-content; justify-items: center; margin: auto;">
             <p style="width: 200px; min-width: 100%">${header}</p>
@@ -123,4 +123,4 @@ export class ItemSelectDialog extends Dialog {
             this.result = result;
         });
     }
-};
+}

--- a/scripts/utils/weapon-utils.js
+++ b/scripts/utils/weapon-utils.js
@@ -5,7 +5,7 @@ export async function getWeapon(actor, predicate, noResultsMessage, priorityPred
     return getSingleWeapon(getWeapons(actor, predicate, noResultsMessage), priorityPredicate);
 }
 
-export async function getSingleWeapon(weapons, priorityPredicate = () => false) {
+export async function getSingleWeapon(weapons, priorityPredicate = () => true) {
     // If there are no weapons, then return nothing
     if (!weapons.length) {
         return;


### PR DESCRIPTION
When reloading using either the **Reload** or **Reload Magazine** macros, if the weapon has no ammunition selected, or its selected ammunition is empty, show a dialog to select ammunition to load.

A checkbox on the dialog allows setting the selected ammunition as the weapon's ammunition, so the dialog will not show again, or not to, so different ammunition can be chosen for each shot.