### PR TITLE
Fix hazards attack rolls causing errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.1 - 2022-12-15 (Pathfinder 2e 4.5.0)
+### Fixes
+- Fix hazards' attack rolls causing errors
+
 ## 3.2.0 - 2022-10-07 (Pathfinder 2e 4.2.3)
 ### Features
 - Allow characters with Double Prey and Triple Threat to select multiple hunted preys

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
     "id": "pf2e-ranged-combat",
     "title": "PF2e Ranged Combat",
     "description": "Utilities for improving ranged combat in Pathfinder 2e.",
-    "version": "3.2.0",
+    "version": "3.2.1",
     "authors": [
         {
             "name": "JDCalvert"
@@ -28,7 +28,7 @@
     },
     "url": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat",
     "manifest": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/releases/latest/download/module.json",
-    "download": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/archive/3.2.0.zip",
+    "download": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/archive/3.2.1.zip",
     "readme": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat",
     "bugs": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/issues",
     "changelog": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/blob/main/CHANGELOG.md",

--- a/scripts/fire-weapon-hook.js
+++ b/scripts/fire-weapon-hook.js
@@ -77,6 +77,9 @@ Hooks.on(
                 }
 
                 const weapon = transformWeapon(contextWeapon);
+                if (!weapon) {
+                    return wrapper(...args);
+                }
 
                 if (!await checkLoaded(actor, weapon)) {
                     return;

--- a/scripts/utils/weapon-utils.js
+++ b/scripts/utils/weapon-utils.js
@@ -62,7 +62,7 @@ export function getWeapons(actor, predicate = () => true, noResultsMessage = nul
 export function transformWeapon(weapon) {
     if (weapon.actor.type === "character") {
         return characterWeaponTransform(weapon);
-    } else if (weapon.actor.type === "npc") {
+    } else if (["npc", "hazard"].includes(weapon.actor.type)) {
         return npcWeaponTransform(weapon);
     } else {
         return null;


### PR DESCRIPTION
In the latest version of the Pathfinder 2e system, hazards were updated so their attack rolls act like character or NPC attack rolls. The module was unable to handle this, and threw a null pointer exception due to the hazard's "weapon" not being transformed into the module's internal weapon type.

This PR updates the code so that hazards' weapons are transformed and, in the case that a weapon is not transformed, skips the module's operations and falls back on the default roll method.