### PR TITLE
Fix references to templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.2 - 2023-01-01 (Pathfinder 2e 4.6.0)
+### Fixes
+- Correct references to templates which were renamed in the system
+
 ## 3.2.1 - 2022-12-15 (Pathfinder 2e 4.5.0)
 ### Fixes
 - Fix hazards' attack rolls causing errors

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
     "id": "pf2e-ranged-combat",
     "title": "PF2e Ranged Combat",
     "description": "Utilities for improving ranged combat in Pathfinder 2e.",
-    "version": "3.2.1",
+    "version": "3.2.2",
     "authors": [
         {
             "name": "JDCalvert"
@@ -28,7 +28,7 @@
     },
     "url": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat",
     "manifest": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/releases/latest/download/module.json",
-    "download": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/archive/3.2.1.zip",
+    "download": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/archive/3.2.2.zip",
     "readme": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat",
     "bugs": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/issues",
     "changelog": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/blob/main/CHANGELOG.md",

--- a/scripts/utils/utils.js
+++ b/scripts/utils/utils.js
@@ -192,8 +192,8 @@ export async function postActionInChat(action) {
 }
 
 export async function postInChat(actor, img, message, actionName = "", numActions = "") {
-    const content = await renderTemplate("./systems/pf2e/templates/chat/action/content.html", { imgPath: img, message: message, });
-    const flavor = await renderTemplate("./systems/pf2e/templates/chat/action/flavor.html", { action: { title: actionName, typeNumber: String(numActions) } });
+    const content = await renderTemplate("./systems/pf2e/templates/chat/action/content.hbs", { imgPath: img, message: message, });
+    const flavor = await renderTemplate("./systems/pf2e/templates/chat/action/flavor.hbs", { action: { title: actionName, typeNumber: String(numActions) } });
 
     await ChatMessage.create({
         type: CONST.CHAT_MESSAGE_TYPES.EMOTE,


### PR DESCRIPTION
Fix references to templates which were renamed in the new version of the Pathfinder 2e system.