### PR TITLE
Fix attacking with default fist attack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.4.2 - 2023-01-13 (Pathfinder 2e 4.6.5)
+### Fixes
+- Fix error that occurred when rolling the default fist attack, due to the previous fix
+
 ## 3.4.1 - 2023-01-10 (Pathfinder 2e 4.6.5)
 ### Fixes
 - Ignore strikes that originate from rule elements

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A module for the Foundry VTT Pathfinder 2e system that provides helper effects and macros for ranged combat.
 
 ![Github All Releases](https://img.shields.io/github/downloads/JDCalvert/FVTT-PF2e-Ranged-Combat/total.svg)
-![Github Latest Release](https://img.shields.io/github/downloads/JDCalvert/fvtt-pf2e-ranged-combat/3.4.1/total)
+![Github Latest Release](https://img.shields.io/github/downloads/JDCalvert/fvtt-pf2e-ranged-combat/3.4.2/total)
 
 ## Issues and System Compatibility
 This module is built for the Pathfinder 2e system, which receives regular updates, and some of those updates may occassionally break the functionality of this module. I will do my best to fix issues caused by updates, but this may require losing support for earlier versions of the system.

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
     "id": "pf2e-ranged-combat",
     "title": "PF2e Ranged Combat",
     "description": "Utilities for improving ranged combat in Pathfinder 2e.",
-    "version": "3.4.1",
+    "version": "3.4.2",
     "authors": [
         {
             "name": "JDCalvert"
@@ -28,7 +28,7 @@
     },
     "url": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat",
     "manifest": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/releases/latest/download/module.json",
-    "download": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/archive/3.4.1.zip",
+    "download": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/archive/3.4.2.zip",
     "readme": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat",
     "bugs": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/issues",
     "changelog": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/blob/main/CHANGELOG.md",

--- a/scripts/utils/weapon-utils.js
+++ b/scripts/utils/weapon-utils.js
@@ -61,7 +61,7 @@ export function getWeapons(actor, predicate = () => true, noResultsMessage = nul
 
 export function transformWeapon(weapon) {
     const originalItem = weapon.actor.items.get(weapon.id)
-    if (!["weapon", "melee"].includes(originalItem.type)) {
+    if (!["weapon", "melee"].includes(originalItem?.type)) {
         return null;
     }
 


### PR DESCRIPTION
The previous fix introduced a check on a weapon's origin item. The default unarmed attack does not have an origin item, which caused a null reference during this check.