### PR TITLE
Fix deleting weapons from Item directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.6.1 - 2023-02-09 (Pathfinder 2e 4.7.2)
+### Fix
+- Fix deleting weapons from the Items directory causing errors
+
 ## 3.6.0 - 2023-02-08 (Pathfinder 2e 4.7.2)
 ### Feature
 - Add hooks for the following macros:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 A module for the Foundry VTT Pathfinder 2e system that provides helper effects and macros for ranged combat.
 
 ![Github All Releases](https://img.shields.io/github/downloads/JDCalvert/FVTT-PF2e-Ranged-Combat/total.svg)
-![Github Latest Release](https://img.shields.io/github/downloads/JDCalvert/fvtt-pf2e-ranged-combat/3.6.0/total)
+![Github Latest Release](https://img.shields.io/github/downloads/JDCalvert/fvtt-pf2e-ranged-combat/3.6.1/total)
 
 ## Issues and System Compatibility
 This module is built for the Pathfinder 2e system, which receives regular updates, and some of those updates may occassionally break the functionality of this module. I will do my best to fix issues caused by updates, but this may require losing support for earlier versions of the system.

--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
     "id": "pf2e-ranged-combat",
     "title": "PF2e Ranged Combat",
     "description": "Utilities for improving ranged combat in Pathfinder 2e.",
-    "version": "3.6.0",
+    "version": "3.6.1",
     "authors": [
         {
             "name": "JDCalvert"
@@ -28,7 +28,7 @@
     },
     "url": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat",
     "manifest": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/releases/latest/download/module.json",
-    "download": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/archive/3.6.0.zip",
+    "download": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/archive/3.6.1.zip",
     "readme": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat",
     "bugs": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/issues",
     "changelog": "https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/blob/main/CHANGELOG.md",

--- a/scripts/fire-weapon-hook.js
+++ b/scripts/fire-weapon-hook.js
@@ -76,42 +76,44 @@ Hooks.on(
             "pf2e-ranged-combat",
             "CONFIG.PF2E.Item.documentClasses.weapon.prototype._onDelete",
             function(wrapper, ...args) {
-                const updates = new Updates(this.actor);
+                if (this.actor) {
+                    const updates = new Updates(this.actor);
 
-                const groupStacks = findGroupStacks(this);
-                const groupStackIds = groupStacks.map(stack => stack.id);
+                    const groupStacks = findGroupStacks(this);
+                    const groupStackIds = groupStacks.map(stack => stack.id);
 
-                // Update all the weapons in the group to remove this item's ID
-                groupStacks.forEach(stack =>
-                    updates.update(
-                        stack,
-                        {
-                            flags: {
-                                "pf2e-ranged-combat": {
-                                    groupIds: groupStackIds
-                                }
-                            }
-                        }
-                    )
-                );
-
-                if (groupStacks.length) {
-                    this.actor.itemTypes.melee.filter(melee => getFlag(melee, "weaponId") === this.id)
-                        .forEach(melee =>
-                            updates.update(
-                                melee,
-                                {
-                                    flags: {
-                                        "pf2e-ranged-combat": {
-                                            weaponId: groupStackIds[0]
-                                        }
+                    // Update all the weapons in the group to remove this item's ID
+                    groupStacks.forEach(stack =>
+                        updates.update(
+                            stack,
+                            {
+                                flags: {
+                                    "pf2e-ranged-combat": {
+                                        groupIds: groupStackIds
                                     }
                                 }
-                            )
-                        );
-                }
+                            }
+                        )
+                    );
 
-                updates.handleUpdates();
+                    if (groupStacks.length) {
+                        this.actor.itemTypes.melee.filter(melee => getFlag(melee, "weaponId") === this.id)
+                            .forEach(melee =>
+                                updates.update(
+                                    melee,
+                                    {
+                                        flags: {
+                                            "pf2e-ranged-combat": {
+                                                weaponId: groupStackIds[0]
+                                            }
+                                        }
+                                    }
+                                )
+                            );
+                    }
+
+                    updates.handleUpdates();
+                }
 
                 wrapper(args);
             },

--- a/scripts/thrown-weapons/change-carry-type.js
+++ b/scripts/thrown-weapons/change-carry-type.js
@@ -84,7 +84,7 @@ export async function changeStowed(wrapper, item, container) {
 
 export function findGroupStacks(item) {
     const groupIds = item.flags["pf2e-ranged-combat"]?.groupIds ?? [item.type === "weapon" ? item.id : item.weaponId];
-    return item.actor?.items.filter(i => groupIds.includes(i.id)) ?? [];
+    return item.actor.items.filter(i => groupIds.includes(i.id));
 }
 
 export async function createNewStack(item, groupStacks, carryType, handsHeld, inSlot, container = null) {

--- a/scripts/thrown-weapons/change-carry-type.js
+++ b/scripts/thrown-weapons/change-carry-type.js
@@ -84,7 +84,7 @@ export async function changeStowed(wrapper, item, container) {
 
 export function findGroupStacks(item) {
     const groupIds = item.flags["pf2e-ranged-combat"]?.groupIds ?? [item.type === "weapon" ? item.id : item.weaponId];
-    return item.actor.items.filter(i => groupIds.includes(i.id));
+    return item.actor?.items.filter(i => groupIds.includes(i.id)) ?? [];
 }
 
 export async function createNewStack(item, groupStacks, carryType, handsHeld, inSlot, container = null) {


### PR DESCRIPTION
On deleting a weapon, the module checks to see if the item's parent actor has any items in the same "group". However, when deleting a weapon from the Items directory, the item has no actor. This caused errors in the console and the item to not be removed from the directory until a refresh.

Now, if the weapon has no actor when it's deleted, we won't try to search for items in the same group because there can't be any.

Fixes #108 