### PR TITLE
Localization of formatted strings

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1,210 +1,182 @@
 {
     "pf2e-ranged-combat": {
-        "basic-terms": {
-            "interact": "Interact",
-            "alchemical-shot": "Alchemical Shot",
-            "conjure-bullet": "Conjure Bullet"
-        },
-        "actions": {
-            "alchemical-crossbow": {
-                "load": {
-                    "warning-load": "",
-                    "return-bomb": "",
-                    "warhing-wasted": "",
-                    "already": "",
-                    "already-hint": "",
-                    "load": "Load",
-                    "not-load": "Do Not Load"
-                },
-                "unload": {
-                    "unload": "Unload",
-                    "not-unload": "Do Not Unload"
-                },
-                "alchemicalCrossbow": {},
-                "elementalBomb": {
-                    "lesser": "Lesser"
-                }
-            },
-            "alchemical-shot": {
-                "warning-feat": "",
-                "warning-weapon": "",
-                "warning-bomb": "",
-                "post-chat": ""
-            }
-        },
-        "ammunition-system": {
-            "actions": {
-                "conjure-bullet": {
-                    "warning-bullet-action": "",
-                    "reloadable": "You have no reloadable weapons.",
-                    "warning-round-effect": "",
-                    "post-chat": ""
-                },
-                "consolidate-ammunition": {
-                    "post-chat": "",
-                    "ui-notification": "Your repeating ammunition is already consolidated!"
-                },
-                "next-chamber": {
-                    "capacity-trait": "You have no weapons with the capacity trait.",
-                    "not-loaded": "",
-                    "already-loaded": "",
-                    "select-chamber": "",
-                    "already-select": "",
-                    "next-chamber": ""
-                },
-                "reload": {
-                    "not-reloadable": "You have no reloadable weapons.",
-                    "magazine-unload": "",
-                    "magazine-empty": "",
-                    "already-loaded": "",
-                    "capacity-fully": "",
-                    "already-ammo": "",
-                    "not-ammunition": "",
-                    "select-ammunition": "",
-                    "enough-ammunition": "",
-                    "selected-ammunition": "",
-                    "reload": "",
-                    "desc-ammunition": ""
-                },
-                "reload-magazine": {
-                    "character-warning": "PF2e Ranged Combat - Magazine Reload can only be used if the Advanced Ammunition System is enabled.",
-                    "npc-warning": "PF2e Ranged Combat - Magazine Reload is currently not supported for NPCs.",
-                    "no-repeating": "You have no repeating weapons.",
-                    "already-warning": "",
-                    "current-warning": "",
-                    "not-ammunition": "",
-                    "select-ammunition": "",
-                    "enough-ammunition": "",
-                    "selected-ammunition": ""
-                },
-                "switch-ammunition": {
-                    "no-weapon": "You have no weapons that use ammunition.",
-                    "no-ammunition": "",
-                    "switch-ammunition": "Select the ammunition to switch to.",
-                    "current": "Current",
-                    "equipped": "Equipped",
-                    "ammunition-select": "Ammunition Select",
-                    "set-as": "Set as ammunition"
-                },
-                "unload": {
-                    "not-loaded": "",
-                    "unload-magazine": "",
-                    "unload-ammunition": "",
-                    "unload-ammunition-effect": "",
-                    "token-unload": "",
-                    "weapon": "You have no loaded weapons."
-                }
-            },
-            "fire-weapon-check": {
-                "magazine-loaded": "",
-                "magazine-empty": "",
-                "not-loaded": "",
-                "both-barrels": "",
-                "chamber-loaded": "",
-                "ammunition-selected": "",
-                "ammunition-remaining": "",
-                "enough-ammunition": ""
-            },
-            "fire-weapon-handler": {
-                "post-chat": "",
-                "conjure-bullet": "",
-                "fires": ""
-            },
-            "utils": {
-                "warning-fully": "",
-                "warning-loaded": "",
-                "conjured-name": "Conjured Round",
-                "ammunition-select": "Ammunition Select",
-                "select": "Select which ammunition to switch to."
-            }
-        },
-        "hunt-prey": {
-            "action-warning": "",
-            "two-allies": ", and can share the effect with two allies",
-            "one-ally": ", and can share the effect with one ally",
-            "targets-three": "",
-            "targets-two": "",
-            "target": "",
-            "no-target": "No target selected.",
-            "targets-max": ""
-        },
-        "npc-weapon-system": {
-            "ui-notification": "You can only use this on NPCs.",
-            "title": "NPC Weapon Configuration",
-            "ok": "Done",
-            "cancel": "Cancel",
-            "hint": "Here, you can configure the NPC to be used by the PF2e Ranged Combat module.",
-            "general": "General",
-            "adv-ammunition": "Enable Advanced Ammunition System",
-            "adv-thrown": "Enable Advanced Thrown Weapon System",
-            "mapping": "Weapon Mapping",
-            "mapping-hint": "You can map each of your NPC's attacks to a weapon and ammunition, so it is treated like a PC's weapon by the module.",
-            "weapon-label": "Weapon",
-            "ammunition-label": "Ammunition"
-        },
-        "thrown-weapon": {
-            "thrown-weapon-check": {
-                "not-equipped": "",
-                "left": ""
-            }
-        },
-        "utils": {
-            "migration": {
-                "multiple-ammunitions": {
-                    "console-info": "PF2e Ranged Combat - Running Migration 1: Multiple Ammunition Update",
-                    "conjured-round": "Conjured Round"
-                },
-                "thrown-weapon-groups": {
-                    "console-info": "PF2e Ranged Combat - Running Migration 2: Thrown Weapon Groups"
-                },
-                "hunted-prey": {
-                    "console-info": "PF2e Ranged Combat - Running Migration 3: Hunted Prey Array"
-                }
-            },
-            "utils": {
-                "warning-single": "You must have a single character selected.",
-                "dialog-title": "PF2e Ranged Combat",
-                "dialog-content": "",
-                "buttons-ok": "OK",
-                "buttons-doNot": "OK (Do not show again)"
-            }
-        },
         "config": {
-            "schema-version": {
+            "schemaVersion": {
                 "name": "Schema Version",
                 "hint": "The current version of the data related to this module"
             },
-            "post-full-action": {
+            "postFullAction": {
                 "name": "Post Full Action from Macros",
                 "hint": "When running macros that simulate taking actions, post the full action description to chat."
             },
-            "post-full-ammunition": {
+            "postFullAmmunition": {
                 "name": "Post Full Ammunition Description",
                 "hint": "When firing a ranged weapon with non-standard ammunition, post the ammunition item to chat."
             },
-            "prevent-fire": {
+            "preventFireNotLoaded": {
                 "name": "Prevent Firing Weapon if not Loaded",
                 "hint": "For weapons with a reload of at least 1, prevent attack rolls using that weapon unless you have the loaded effect for that weapon."
             },
-            "advanced-ammunition": {
+            "advancedAmmunitionSystemPlayer": {
                 "name": "Advanced Ammunition System (Player)",
                 "hint": "Track loaded ammunition for reloadable and repeating weapons. This overrides Prevent Firing Weapon if not Loaded."
             },
-            "advanced-thrown-weapon": {
+            "advancedThrownWeaponSystemPlayer": {
                 "name": "Advanced Thrown Weapon System (Player)",
                 "hint": "Handle thrown weapons being dropped after use, and require another weapon to be drawn before another attack."
             },
-            "required-permission": {
+            "requiredPermissionToShowMessages": {
                 "name": "Minimum Permission to See Messages",
-                "hint": "Several functions of this module send messages to chat, for example Reloading. This will hide those messages for players without the required permission over the actor performing the action.",
-                "none": "None",
-                "limited": "Limited",
-                "observer": "Observer",
-                "owner": "Owner"
+                "hint": "Several functions of this module send messages to chat, for example Reloading.\nThis will hide those messages for players without the required permission over the actor performing the action."
             },
-            "hide-token": {
+            "hideTokenIcons": {
                 "name": "Hide Token Effect Icons",
                 "hint": "Hide the token icons for effects created by this module."
+            }
+        },
+        "huntPrey": {
+            "warningNoAction": "{tokenName} does not have the Hunt Prey action.",
+            "maxTargetsOne": "one",
+            "maxTargetsTwo": "two",
+            "maxTargetsThree": "three",
+            "shareWithTwo": ", and can share the effect with two allies",
+            "shareWithOne": ", and can share the effect with one ally",
+            "huntThreeTargets": "{tokenName} makes {target1}, {target2}, and {target3} their hunted prey.",
+            "huntTwoTargets": "{tokenName} makes {target1} and {target2} their hunted prey",
+            "huntOneTarget": "{tokenName} makes {target1} their hunted prey",
+            "warningNoTarget": "No target selected.",
+            "warningTooManyTargets": "You may only have {maxTargets} hunted prey."
+        },
+        "thrownWeapons": {
+            "warningNotEquipped": "{weapon} is not equipped!",
+            "warningNoAmmoLeft": "You have no {weapon} left!"
+        },
+        "npcWeaponSystem": {
+            "warningNpcOnly": "You can only use this on NPCs.",
+            "dialog": {
+                "title": "NPC Weapon Configuration",
+                "hint": "Here, you can configure the NPC to be used by the PF2e Ranged Combat module.",
+                "legendGeneral": "General",
+                "enableAmmunition": "Enable Advanced Ammunition System",
+                "enableThrown": "Enable Advanced Thrown Weapon System",
+                "legendMapping": "Weapon Mapping",
+                "mappingHint": "You can map each of your NPC's attacks to a weapon and ammunition, so it is treated like a PC's weapon by the module.",
+                "labelWeapon": "Weapon",
+                "weaponTypeMelee": "Melee",
+                "weaponTypeRanged": "Ranged",
+                "labelAmmunition": "Ammunition",
+                "done": "Done",
+                "cancel": "Cancel"
+            }
+        },
+        "ammunitionSystem": {
+            "fireWeapon": "{actor} fires {ammunition}.",
+            "fireConjuredRound": "{actor} fires their conjured round.",
+            "utils": {
+                "warningFullyLoaded": "{weapon} is already fully loaded.",
+                "warningLoaded": "{weapon} is already loaded."
+            },
+            "actions": {
+                "conjureBullet": {
+                    "warningNoAction": "{token} does not have the Conjure Bullet action.",
+                    "noReloadableWeapons": "You have no reloadable weapons.",
+                    "warningSingleRound": "{weapon} can only be loaded with one conjured round.",
+                    "chatMessage": "{token} uses Conjure Bullet to load their {weapon}.",
+                    "chatActionName": "Conjure Bullet"
+                },
+                "consolidateAmmunition": {
+                    "chatMessage": "{token} consolidates their ammunition.",
+                    "chatActionInteract": "Interact",
+                    "infoAlreadyConsolidated": "Your repeating ammunition is already consolidated!"
+                },
+                "nextChamber": {
+                    "noCapacityWeapons": "You have no weapons with the capacity trait.",
+                    "warningNotLoaded": "{weapon} is not loaded!",
+                    "warningAlreadyLoaded": "{weapon} already has a chamber loaded with {ammunition} selected!",
+                    "chatMessageSelectChamber": "{token} selects a chamber loaded with {ammunition} on their {weapon}.",
+                    "warningAlreadySelected": "{weapon} already has a loaded chamber selected!",
+                    "chatMessageSelectNextChamber": "{token} selects the next loaded chamber on their {weapon}."
+                },
+                "reloadMagazine": {
+                    "warningAdvancedAmmunitionNeeded": "PF2e Ranged Combat - Magazine Reload can only be used if the Advanced Ammunition System is enabled.",
+                    "warningNpcNotSupported": "PF2e Ranged Combat - Magazine Reload is currently not supported for NPCs.",
+                    "warningNoRepeatingWeapons": "You have no repeating weapons.",
+                    "warningFullyLoaded": "{weapon} is already loaded with a full magazine.",
+                    "warningAlreadyMoreAmmo": "{weapon}'s current magazine is already loaded with as much ammunition as {ammo}",
+                    "tokenLoadsAmmo": "{token} loads their {weapon} with {ammo} ({charges}/{maxCharges}).",
+                    "warningNoCompatibleAmmunition": "You have no equipped ammunition compatible with your {weapon}.",
+                    "noAmmunitionSelectNew": "You have no ammunition selected for your {weapon}.</p><p>Select the ammunition to load.",
+                    "warningNotEnoughAmmunition": "You don't have enough ammunition to reload your {weapon}.",
+                    "notEnoughAmmunitionSelectNew": "Your selected ammunition for your {weapon} is empty.</p><p>Select new ammunition to load."
+                },
+                "reload": {
+                    "warningNoReloadableWeapons": "You have no reloadable weapons.",
+                    "warningNoMagazineLoaded": "{weapon} has no magazine loaded!",
+                    "warningMagazineEmpty": "{weapon}'s magazine is empty!",
+                    "warningAlreadyLoaded": "{weapon} is already loaded.",
+                    "warningAlreadyFullyLoaded": "{weapon} is already fully loaded.",
+                    "warningAlreadyLoadedWithAmmo": "{weapon} is already loaded with {ammo}.",
+                    "warningNoCompatibleAmmunition": "You have no equipped ammunition compatible with {weapon}.",
+                    "noAmmunitionSelectNew": "You have no ammunition selected for your {weapon}.</p><p>Select the ammunition to load.",
+                    "warningNotEnoughAmmunition": "Not enough ammunition to reload {weapon}.",
+                    "notEnoughAmmunitionSelectNew": "Your selected ammunition for your {weapon} is empty.</p><p>Select new ammunition to load.",
+                    "tokenReloadsWeapon": "{token} reloads their {weapon}",
+                    "withAmmunition": "with {ammunitionName}."
+                },
+                "switchAmmunition": {
+                    "warningNoWeaponUsesAmmunition": "You have no weapons that use ammunition.",
+                    "warningNoCompatibleAmmunitionAvailable": "You have no equipped ammunition compatible with your {weapon}.",
+                    "noCompatibleAmmunitionSelectNew": "Select the ammunition to switch to.",
+                    "dialogTitle": "Ammunition Select"
+                },
+                "unload": {
+                    "warningNotLoaded": "{weapon} is not loaded!",
+                    "tokenUnloadsAmmunitionFromWeapon": "{token} unloads {ammunition} from their {weapon}.",
+                    "tokenUnloadsWeapon": "{token} unloads their {weapon}",
+                    "noLoadedWeapons": "You have no loaded weapons."
+                }
+            }
+        },
+        "utils": {
+            "warningDialog1": "You cannot fire this weapon because:",
+            "warningDialog2": "This is a feature of the PF2e Ranged Combat module.",
+            "warningDialog3": "You can learn how to use the module <a href=\"https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/blob/main/README.md\">here</a>.",
+            "buttonOK": "OK",
+            "buttonDoNotShowAgain": "OK (Do not show again)",
+            "migration": {
+                "multipleAmmunitions.consoleInfo": "PF2e Ranged Combat - Running Migration 1: Multiple Ammunition Update",
+                "thrownWeaponGroups.consoleInfo": "PF2e Ranged Combat - Running Migration 2: Thrown Weapon Groups",
+                "huntedPrey.consoleInfo": "PF2e Ranged Combat - Running Migration 3: Hunted Prey Array"
+            }
+        },
+        "actions": {
+            "alchemicalCrossbow": {
+                "warningAlreadyLoaded": "{token}'s {weapon} is already loaded with {bomb}.",
+                "bombWillBeReturned": "{bomb} will be returned to your inventory.",
+                "usesWillBeWasted": "The remaining uses of {bomb} will be wasted.",
+                "loadInsteadDialogTitle": "{weapon} Already Loaded",
+                "weaponIsLoadedWithCharges": "{weapon} is loaded with {bomb} with {charges}/{maxCharges} uses remaining.",
+                "loadInstead": "Would you like to load {bomb} instead?",
+                "buttonLoad": "Load",
+                "buttonDoNotLoad": "Do Not Load",
+                "lesser": "Lesser",
+                "tokenLoadsWeaponWithBomb": "{token} loads their {weapon} with {bomb}.",
+                "warningWeaponNotLoaded": "{token}'s {weapon} is not loaded with an alchemical bomb.",
+                "shouldUnloadDialogTitle": "{bomb} discard",
+                "shouldUnloadDialogRestWasted": "The remaining uses will be wasted",
+                "shouldUnloadInstead": "Are you sure you want to unload {bomb} from {weapon}?",
+                "buttonUnload": "Unload",
+                "buttonDoNotUnload": "Do Not Unload",
+                "tokenUnloadsBombFromWeapon": "{token} unloads {bomb} from their {weapon}.",
+                "warningNoAlchemicalCrossbow": "{token} has no Alchemical Crossbow.",
+                "warningNoLesserAlchemicalBombs": "{token} has no lesser alchemical bombs that deal energy damage."
+            },
+            "alchemicalShot": {
+                "warningNoFeat": "{token} does not have the Alchemical Shot feat.",
+                "warningNotWieldingProperWeapon": "{token} is not wielding a firearm or crossbow.",
+                "warningNoAlchenicalBombs": "{token} has no alchemical bombs.",
+                "tokenPoursBombIntoWeapon": "{token} pours the contents of {bomb} into their {weapon}.",
+                "alchemicalShot": "Alchemical Shot"
             }
         }
     }

--- a/module.json
+++ b/module.json
@@ -57,11 +57,11 @@
             "system": "pf2e"
         }
     ],
-    "language": [
+    "languages": [
         {
             "lang": "en",
             "name": "English",
-            "path": "languages/en.json",
+            "path": "lang/en.json",
             "flags": {}
         }
     ]

--- a/scripts/actions/alchemical-shot.js
+++ b/scripts/actions/alchemical-shot.js
@@ -4,6 +4,9 @@ import { getWeapon } from "../utils/weapon-utils.js";
 const ALCHEMICAL_SHOT_FEAT_ID = "Compendium.pf2e.feats-srd.Q1O4P1YIkCfeedHH";
 const ALCHEMICAL_SHOT_EFFECT_ID = "Compendium.pf2e-ranged-combat.effects.IYcN1TxztAmnKXi4";
 
+const localize = (key) => game.i18n.localize("pf2e-ranged-combat.actions.alchemicalShot." + key)
+const format = (key, data) => game.i18n.format("pf2e-ranged-combat.actions.alchemicalShot." + key, data)
+
 export async function alchemicalShot() {
     const { actor, token } = getControlledActorAndToken();
     if (!actor) {
@@ -12,14 +15,14 @@ export async function alchemicalShot() {
 
     const alchemicalShotFeat = getItemFromActor(actor, ALCHEMICAL_SHOT_FEAT_ID);
     if (!alchemicalShotFeat) {
-        showWarning(`${token.name} does not have the Alchemical Shot feat.`); /*Localization?*/
+        showWarning(format("warningNoFeat", { token: token.name }));
         return;
     }
 
     const weapon = await getWeapon(
         actor,
         weapon => weapon.isEquipped && (weapon.group === "firearm" || weapon.isCrossbow),
-        `${token.name} is not wielding a firearm or crossbow.` /*Localization?*/
+        showWarning(format("warningNotWieldingProperWeapon", { token: token.name }))
     );
     if (!weapon) {
         return;
@@ -30,7 +33,7 @@ export async function alchemicalShot() {
         weapon =>
             weapon.baseType === "alchemical-bomb"
             && weapon.quantity > 0,
-        `${token.name} has no alchemical bombs.` /*Localization?*/
+        format("warningNoAlchemicalBombs", { token: token.name })
     );
     if (!bomb) {
         return;
@@ -58,7 +61,7 @@ export async function alchemicalShot() {
             rulesSelections: {
                 ...alchemicalShotEffectSource.flags?.pf2e?.rulesSelections,
                 weapon: weapon.id,
-                damageType:  bomb.damageType,
+                damageType: bomb.damageType,
                 persistentDamageDice: bomb.level >= 17 ? 3 : bomb.level >= 11 ? 2 : 1
             }
         },
@@ -81,8 +84,8 @@ export async function alchemicalShot() {
     await postInChat(
         actor,
         bomb.img,
-        `${token.name} pours the contents of ${bomb.name} into their ${weapon.name}.`, /*Localization?*/
-        game.i18n.localize("pf2e-ranged-combat.basic-terms.alchemical-shot"),
+        format("tokenPoursBombIntoWeapon", { token: token.name, weapon: weapon.name, bomb: bomb.name }),
+        localize("alchemicalShot"),
         2
     );
 

--- a/scripts/ammunition-system/actions/conjure-bullet.js
+++ b/scripts/ammunition-system/actions/conjure-bullet.js
@@ -5,6 +5,9 @@ import { CONJURED_ROUND_EFFECT_ID, CONJURED_ROUND_ITEM_ID, CONJURE_BULLET_ACTION
 import { checkFullyLoaded, isFullyLoaded } from "../utils.js";
 import { setLoadedChamber } from "./next-chamber.js";
 
+const localize = (key) => game.i18n.localize("pf2e-ranged-combat.ammunitionSystem.actions.conjureBullet." + key)
+const format = (key, data) => game.i18n.format("pf2e-ranged-combat.ammunitionSystem.actions.conjureBullet." + key, data)
+
 export async function conjureBullet() {
     const { actor, token } = getControlledActorAndToken();
     if (!actor) {
@@ -13,12 +16,12 @@ export async function conjureBullet() {
 
     const conjureBulletAction = getItemFromActor(actor, CONJURE_BULLET_ACTION_ID);
     if (!conjureBulletAction) {
-        showWarning(`${token.name} does not have the Conjure Bullet action.`); /*Localization?*/
+        showWarning(format("warningNoAction", { token: token.name }));
         return;
     }
 
     const weapon = await getSingleWeapon(
-        getWeapons(actor, weapon => weapon.requiresLoading && !weapon.isRepeating, game.i18n.localize("pf2e-ranged-combat.ammunition-system,actions.conjure-bullet.reloadable")),
+        getWeapons(actor, weapon => weapon.requiresLoading && !weapon.isRepeating, localize("noReloadableWeapons")),
         weapon => !isFullyLoaded(actor, weapon)
     );
     if (!weapon) {
@@ -27,7 +30,7 @@ export async function conjureBullet() {
 
     const conjuredRoundEffect = getEffectFromActor(actor, CONJURED_ROUND_EFFECT_ID, weapon.id);
     if (conjuredRoundEffect) {
-        showWarning(`${weapon.name} can only be loaded with one conjured round.`); /*Localization?*/
+        showWarning(format("warningSingleRound", { weapon: weapon.name }));
         return;
     }
 
@@ -64,8 +67,8 @@ export async function conjureBullet() {
     await postInChat(
         token.actor,
         CONJURE_BULLET_IMG,
-        `${token.name} uses Conjure Bullet to load their ${weapon.name}.`, /*Localization?*/
-        game.i18n.localize("pf2e-ranged-combat.basic-terms.conjure-bullet"),
+        format("chatMessage", { token: token.name, weapon: weapon.name }),
+        localize("chatActionName"),
         1,
     );
 

--- a/scripts/ammunition-system/actions/consolidate-ammunition.js
+++ b/scripts/ammunition-system/actions/consolidate-ammunition.js
@@ -1,5 +1,9 @@
 import { getControlledActorAndToken, getItem, postInChat, Updates } from "../../utils/utils.js";
 
+const localize = (key) => game.i18n.localize("pf2e-ranged-combat.ammunitionSystem.actions.consolidateAmmunition." + key)
+const format = (key, data) => game.i18n.format("pf2e-ranged-combat.ammunitionSystem.actions.consolidateAmmunition." + key, data)
+
+
 export async function consolidateRepeatingWeaponAmmunition() {
     const { actor, token } = getControlledActorAndToken();
     if (!actor) {
@@ -9,7 +13,7 @@ export async function consolidateRepeatingWeaponAmmunition() {
     // Find all the repeating ammunition stacks
     const ammunitionStacks = actor.itemTypes.consumable.filter(consumable => consumable.isAmmunition && consumable.system.charges.max > 1);
     const ammunitionStacksBySourceId = ammunitionStacks.reduce(
-        function(map, stack) {
+        function (map, stack) {
             const mapEntry = map[stack.sourceId];
             if (!mapEntry) {
                 map[stack.sourceId] = {
@@ -104,13 +108,13 @@ export async function consolidateRepeatingWeaponAmmunition() {
         postInChat(
             actor,
             ammunitionStacks[0].img,
-            `${token.name} consolidates their ammunition.`,
-            game.i18n.localize("pf2e-ranged-combat.basic-terms.interact"),
+            format("chatMessage", { token: token.name }),
+            game.i18n.localize("PF2E.Actions.Interact.Title"),
             ""
         );
         await updates.handleUpdates();
     } else {
-        ui.notifications.info(game.i18n.localize("pf2e-ranged-combat.ammunition-system.actions.consolidate-ammunition.ui-notification"));
+        ui.notifications.info(localize("infoAlreadyConsolidated"));
     }
 }
 

--- a/scripts/ammunition-system/actions/next-chamber.js
+++ b/scripts/ammunition-system/actions/next-chamber.js
@@ -3,6 +3,9 @@ import { getSingleWeapon, getWeapons } from "../../utils/weapon-utils.js";
 import { CHAMBER_LOADED_EFFECT_ID, CONJURED_ROUND_ITEM_ID, SELECT_NEXT_CHAMBER_IMG } from "../constants.js";
 import { getSelectedAmmunition, isLoaded } from "../utils.js";
 
+const localize = (key) => game.i18n.localize("pf2e-ranged-combat.ammunitionSystem.actions.nextChamber." + key)
+const format = (key, data) => game.i18n.format("pf2e-ranged-combat.ammunitionSystem.actions.nextChamber." + key, data)
+
 export async function nextChamber() {
     const { actor, token } = getControlledActorAndToken();
     if (!actor) {
@@ -10,7 +13,7 @@ export async function nextChamber() {
     }
 
     const weapon = await getSingleWeapon(
-        getWeapons(actor, weapon => weapon.isCapacity, game.i18n.localize("pf2e-ranged-combat.ammunition-system.actions.next-chamber.capacity-trait")),
+        getWeapons(actor, weapon => weapon.isCapacity, localize("noCapacityWeapons")),
         weapon => isLoaded(actor, weapon) && !getEffectFromActor(actor, CHAMBER_LOADED_EFFECT_ID, weapon.id)
     );
     if (!weapon) {
@@ -18,7 +21,7 @@ export async function nextChamber() {
     }
 
     if (!isLoaded(actor, weapon)) {
-        showWarning(`${weapon.name} is not loaded!`); /*Localization?*/
+        showWarning(format("warningNotLoaded", { weapon: weapon.name }));
         return;
     }
 
@@ -34,7 +37,7 @@ export async function nextChamber() {
         if (chamberLoadedEffect) {
             const chamberAmmunition = getFlag(chamberLoadedEffect, "ammunition");
             if (chamberAmmunition.sourceId === selectedAmmunition.sourceId) {
-                showWarning(`${weapon.name} already has a chamber loaded with ${selectedAmmunition.name} selected!`); /*Localization?*/
+                showWarning(format("weaponAlreadyLoaded", { weapon: weapon.name, selectedAmmunition: ammunition.name }));
                 return;
             }
         }
@@ -43,14 +46,14 @@ export async function nextChamber() {
         await postInChat(
             token.actor,
             SELECT_NEXT_CHAMBER_IMG,
-            `${token.name} selects a chamber loaded with ${selectedAmmunition.name} on their ${weapon.name}.`, /*Localization?*/
-            game.i18n.localize("pf2e-ranged-combat.basic-terms.interact"),
+            format("chatMessageSelectChamber", { token: token.name, selectedAmmunition: ammunition.name, weapon: weapon.name }),
+            game.i18n.localize("PF2E.Actions.Interact.Title"),
             1,
         );
     } else {
         const chamberLoadedEffect = getEffectFromActor(actor, CHAMBER_LOADED_EFFECT_ID, weapon.id);
         if (chamberLoadedEffect) {
-            showWarning(`${weapon.name} already has a loaded chamber selected!`); /*Localization?*/
+            showWarning(format("warningAlreadySelected", { weapon: weapon.name }));
             return;
         }
 
@@ -58,8 +61,8 @@ export async function nextChamber() {
         await postInChat(
             token.actor,
             SELECT_NEXT_CHAMBER_IMG,
-            `${token.name} selects the next loaded chamber on their ${weapon.name}.`, /*Localization?*/
-            game.i18n.localize("pf2e-ranged-combat.basic-terms.interact"),
+            format("chatMessageSelectNextChamber", { token: token.name, weapon: weapon.name }),
+            game.i18n.localize("PF2E.Actions.Interact.Title"),
             1,
         );
     }

--- a/scripts/ammunition-system/actions/reload-magazine.js
+++ b/scripts/ammunition-system/actions/reload-magazine.js
@@ -5,6 +5,9 @@ import { MAGAZINE_LOADED_EFFECT_ID, RELOAD_MAGAZINE_IMG } from "../constants.js"
 import { selectAmmunition } from "./switch-ammunition.js";
 import { unloadMagazine } from "./unload.js";
 
+const localize = (key) => game.i18n.localize("pf2e-ranged-combat.ammunitionSystem.actions.reloadMagazine." + key)
+const format = (key, data) => game.i18n.format("pf2e-ranged-combat.ammunitionSystem.actions.reloadMagazine." + key, data)
+
 /**
  * Replace the magazine in a repeating weapon.
  * - If no new magazine is selected, only remove the current magazine.
@@ -21,10 +24,10 @@ export async function reloadMagazine() {
 
     if (!useAdvancedAmmunitionSystem(actor)) {
         if (actor.type === "character") {
-            showWarning(game.i18n.localize("pf2e-ranged-combat.ammunition-system.actions.reload-magazine.character-warning"));
+            showWarning(localize("warningAdvancedAmmunitionNeeded"));
             return;
         } else if (actor.type === "npc") {
-            showWarning(game.i18n.localize("pf2e-ranged-combat.ammunition-system.actions.reload-magazine.npc-warning"));
+            showWarning(localize("warningNpcNotSupported"));
             return;
         }
     }
@@ -32,7 +35,7 @@ export async function reloadMagazine() {
     const weapon = await getWeapon(
         actor,
         weapon => weapon.isRepeating,
-        game.i18n.localize("pf2e-ranged-combat.ammunition-system.actions.reload-magazine.no-repeating"),
+        localize("warningNoRepeatingWeapons"),
         weapon => {
             const magazineLoadedEffect = getEffectFromActor(actor, MAGAZINE_LOADED_EFFECT_ID, weapon.id);
             return !magazineLoadedEffect || !getFlag(magazineLoadedEffect, "remaining");
@@ -64,11 +67,11 @@ export async function reloadMagazine() {
 
         if (magazineRemaining === magazineCapacity && magazineSourceId === selectedAmmunitionSourceId) {
             // The current magazine is full, and the selected ammunition is the same
-            showWarning(`${weapon.name} is already loaded with a full magazine.`); /*Localization?*/
+            showWarning(format("warningFullyLoaded", { weapon: weapon.name }));
             return;
         } else if (magazineRemaining === ammo.system.charges.value && magazineSourceId === selectedAmmunitionSourceId) {
             // The current magazine is the same, and has the same remaining ammunition, as the new one
-            showWarning(`${weapon.name}'s current magazine is already loaded with as much ammunition as ${ammo.name}`); /*Localization?*/
+            showWarning(format("warningAlreadyMoreAmmo", { weapon: weapon.name, ammo: ammo.name }));
             return;
         } else {
             // We actually want to reload, either for a magazine with more ammunition remaining, or for a different type of ammunition
@@ -108,7 +111,7 @@ export async function reloadMagazine() {
                 quantity: ammo.quantity - 1,
                 charges: {
                     value: ammo.system.charges.max
-                }            
+                }
             }
         }
     );
@@ -116,8 +119,8 @@ export async function reloadMagazine() {
     await postInChat(
         actor,
         RELOAD_MAGAZINE_IMG,
-        `${token.name} loads their ${weapon.name} with ${ammo.name} (${ammo.system.charges.value}/${ammo.system.charges.max}).`, /*Localization?*/
-        game.i18n.localize("pf2e-ranged-combat.basic-terms.interact"),
+        format("tokenLoadsAmmo", { token: token.name, ammo: ammo.name, charges: ammo.system.charges.value, maxCharges: ammo.system.charges.max }),
+        game.i18n.localize("PF2E.Actions.Interact.Title"),
         String(numActions)
     );
 
@@ -127,13 +130,13 @@ export async function reloadMagazine() {
 
 async function getAmmunition(weapon, updates) {
     const ammunition = weapon.ammunition;
-    
+
     if (!ammunition) {
         return await selectAmmunition(
             weapon,
             updates,
-            `You have no equipped ammunition compatible with your ${weapon.name}.`, /*Localization?*/
-            `You have no ammunition selected for your ${weapon.name}.</p><p>Select the ammunition to load.`, /*Localization?*/
+            format("warningNoCompatibleAmmunition", { weapon: weapon.name }),
+            format("noAmmunitionSelectNew", { weapon: weapon.name }),
             false,
             false
         )
@@ -141,8 +144,8 @@ async function getAmmunition(weapon, updates) {
         return await selectAmmunition(
             weapon,
             updates,
-            `You don't have enough ammunition to reload your ${weapon.name}.`, /*Localization?*/
-            `Your selected ammunition for your ${weapon.name} is empty.</p><p>Select new ammunition to load.`, /*Localization?*/
+            format("warningNotEnoughAmmunition", { weapon: weapon.name }),
+            format("notEnoughAmmunitionSelectNew", { weapon: weapon.name }),
             true,
             false
         )

--- a/scripts/ammunition-system/actions/reload.js
+++ b/scripts/ammunition-system/actions/reload.js
@@ -7,6 +7,9 @@ import { setLoadedChamber } from "./next-chamber.js";
 import { selectAmmunition } from "./switch-ammunition.js";
 import { unloadAmmunition } from "./unload.js";
 
+const localize = (key) => game.i18n.localize("pf2e-ranged-combat.ammunitionSystem.actions.reload." + key)
+const format = (key, data) => game.i18n.format("pf2e-ranged-combat.ammunitionSystem.actions.reload." + key, data)
+
 export async function reload() {
     const { actor, token } = getControlledActorAndToken();
     if (!actor) {
@@ -16,7 +19,7 @@ export async function reload() {
     const weapon = await getWeapon(
         actor,
         weapon => weapon.requiresLoading,
-        game.i18n.localize("pf2e-ranged-combat.ammunition-system.actions.reload.not-reloadable"),
+        localize("warningNoReloadableWeapons"),
         weapon => !isFullyLoaded(actor, weapon)
     );
     if (!weapon) {
@@ -33,14 +36,14 @@ export async function reload() {
 export async function reloadNPCs() {
     try {
         CONFIG.pf2eRangedCombat.silent = true;
-                
+
         const nonPlayerTokens = Array.from(canvas.scene.tokens).filter(token => !token.actor.hasPlayerOwner);
         for (const token of nonPlayerTokens) {
             const actor = token.actor;
             const weapons = await getWeapons(
                 actor,
                 weapon => weapon.requiresLoading,
-                game.i18n.localize("pf2e-ranged-combat.ammunition-system.actions.reload.not-reloadable")
+                localize("noReloadableWeapons"),
             );
 
             const updates = new Updates(actor);
@@ -63,17 +66,17 @@ async function performReload(actor, token, weapon, updates) {
             // is still only consumed when we fire
             const magazineLoadedEffect = getEffectFromActor(actor, MAGAZINE_LOADED_EFFECT_ID, weapon.id);
             if (!magazineLoadedEffect) {
-                showWarning(`${weapon.name} has no magazine loaded!`); /*Localization?*/
+                showWarning(format("warningNoMagazineLoaded", { weapon: weapon.name }));
                 return;
             } else if (getFlag(magazineLoadedEffect, "remaining") < 1) {
-                showWarning(`${weapon.name}'s magazine is empty!`); /*Localization?*/
+                showWarning(format("warningMagazineEmpty", { weapon: weapon.name }));
                 return;
             }
 
             // If the weapon is already loaded, we don't need to do it again
             const loadedEffect = getEffectFromActor(actor, LOADED_EFFECT_ID, weapon.id);
             if (loadedEffect) {
-                showWarning(`${weapon.name} is already loaded.`); /*Localization?*/
+                showWarning(formate("warningAlreadyLoaded", { weapon: weapon.name }));
                 return;
             }
 
@@ -92,7 +95,7 @@ async function performReload(actor, token, weapon, updates) {
 
             if (weapon.capacity) {
                 if (isFullyLoaded(actor, weapon)) {
-                    showWarning(`${weapon.name} is already fully loaded.`); /*Localization?*/
+                    showWarning(format("warningAlreadyFullyLoaded", { weapon: weapon.name }));
                     return;
                 }
 
@@ -173,7 +176,7 @@ async function performReload(actor, token, weapon, updates) {
                     // If the selected ammunition is the same as what's already loaded, don't reload
                     const loadedAmmunition = getFlag(loadedEffect, "ammunition");
                     if (ammo.sourceId === loadedAmmunition.sourceId) {
-                        showWarning(`${weapon.name} is already loaded with ${ammo.name}.`); /*Localization?*/
+                        showWarning(format("warningAlreadyLoadedWithAmmo", { weapon: weapon.name, ammo: ammo.name }));
                         return;
                     }
                     await unloadAmmunition(actor, weapon, updates);
@@ -264,8 +267,8 @@ async function getAmmunition(weapon, updates) {
         return await selectAmmunition(
             weapon,
             updates,
-            `You have no equipped ammunition compatible with ${weapon.name}.`, /*Localization?*/
-            `You have no ammunition selected for your ${weapon.name}.</p><p>Select the ammunition to load.`, /*Localization?*/
+            format("warningNoCompatibleAmmunition", { weapon: weapon.name }),
+            format("noAmmunitionSelectNew", { weapon: weapon.name }),
             false,
             false
         );
@@ -273,8 +276,8 @@ async function getAmmunition(weapon, updates) {
         return await selectAmmunition(
             weapon,
             updates,
-            `Not enough ammunition to reload ${weapon.name}.`, /*Localization?*/
-            `Your selected ammunition for your ${weapon.name} is empty.</p><p>Select new ammunition to load.`, /*Localization?*/
+            format("warningNotEnoughAmmunition", { weapon: weapon.name }),
+            format("notEnoughAmmunitionSelectNew", { weapon: weapon.name }),
             true,
             false
         );
@@ -285,9 +288,9 @@ async function getAmmunition(weapon, updates) {
 
 async function postReloadToChat(token, weapon, ammunitionName) {
     const reloadActions = weapon.reload;
-    let desc = `${token.name} reloads their ${weapon.name}`; /*Localization?*/
+    let desc = format("tokenReloadsWeapon", { token: token.name, weapon: weapon.name });
     if (ammunitionName) {
-        desc = `${desc} with ${ammunitionName}.`; /*Localization?*/
+        desc = desc + " " + format("withAmmunition", { ammunitionName: ammunitionName });
     } else {
         desc = `${desc}.`;
     }
@@ -296,7 +299,7 @@ async function postReloadToChat(token, weapon, ammunitionName) {
         token.actor,
         RELOAD_AMMUNITION_IMG,
         desc,
-        game.i18n.localize("pf2e-ranged-combat.basic-terms.interact"),
+        game.i18n.localize("PF2E.Actions.Interact.Title"),
         reloadActions <= 3 ? String(reloadActions) : "",
     );
 }

--- a/scripts/ammunition-system/actions/switch-ammunition.js
+++ b/scripts/ammunition-system/actions/switch-ammunition.js
@@ -2,13 +2,16 @@ import { ItemSelectDialog } from "../../utils/item-select-dialog.js";
 import { getControlledActorAndToken, showWarning, Updates } from "../../utils/utils.js";
 import { getWeapon } from "../../utils/weapon-utils.js";
 
+const localize = (key) => game.i18n.localize("pf2e-ranged-combat.ammunitionSystem.actions.switchAmmunition." + key)
+const format = (key, data) => game.i18n.format("pf2e-ranged-combat.ammunitionSystem.actions.switchAmmunition." + key, data)
+
 export async function switchAmmunition() {
     const { actor, token } = getControlledActorAndToken();
     if (!actor) {
         return;
     }
 
-    const weapon = await getWeapon(actor, weapon => weapon.usesAmmunition, game.i18n.localize("pf2e-ranged-combat.ammunition-system.actions.switch-ammunition.no-weapon"));
+    const weapon = await getWeapon(actor, weapon => weapon.usesAmmunition, localize("warningNoWeaponUsesAmmunition"));
     if (!weapon) {
         return;
     }
@@ -18,8 +21,8 @@ export async function switchAmmunition() {
     await selectAmmunition(
         weapon,
         updates,
-        `You have no equipped ammunition compatible with your ${weapon.name}.`, /*Localization?*/
-        game.i18n.localize("pf2e-ranged-combat.ammunition-system.actions.switch-ammunition.switch-ammunition"),
+        format("warningNoCompatibleAmmunitionAvailable", { weapon: weapon }),
+        localize("noCompatibleAmmunitionSelectNew"),
         true,
         true
     );
@@ -60,15 +63,15 @@ export async function selectAmmunition(
     if (weapon.ammunition) {
         const currentAmmunition = availableAmmunitionChoices.findSplice(ammo => ammo.id === weapon.ammunition.id);
         if (currentAmmunition) {
-            ammunitionMap.set(game.i18n.localize("pf2e-ranged-combat.ammunition-system.actions.switch-ammunition.current"), [currentAmmunition]);
+            ammunitionMap.set("Current", [currentAmmunition]);
         }
     };
     if (availableAmmunitionChoices.length) {
-        ammunitionMap.set(game.i18n.localize("pf2e-ranged-combat.ammunition-system.actions.switch-ammunition.equipped"), availableAmmunitionChoices);
+        ammunitionMap.set("Equipped", availableAmmunitionChoices);
     }
 
     const result = await ItemSelectDialog.getItemWithOptions(
-        game.i18n.localize("pf2e-ranged-combat.ammunition-system.actions.switch-ammunition.ammunition-select"),
+        localize("dialogTitle"),
         selectNewMessage,
         ammunitionMap,
         alwaysSetAsAmmunition
@@ -76,7 +79,7 @@ export async function selectAmmunition(
             : [
                 {
                     id: "set-as-ammunition",
-                    label: game.i18n.localize("pf2e-ranged-combat.ammunition-system.actions.switch-ammunition.set-as"),
+                    label: "Set as ammunition",
                     defaultValue: defaultSetAsAmmunition
                 }
             ]

--- a/scripts/ammunition-system/actions/unload.js
+++ b/scripts/ammunition-system/actions/unload.js
@@ -3,6 +3,9 @@ import { getWeapon } from "../../utils/weapon-utils.js";
 import { CONJURED_ROUND_EFFECT_ID, CONJURED_ROUND_ITEM_ID, LOADED_EFFECT_ID, MAGAZINE_LOADED_EFFECT_ID } from "../constants.js";
 import { clearLoadedChamber, getSelectedAmmunition, isLoaded, removeAmmunition, removeAmmunitionAdvancedCapacity } from "../utils.js";
 
+const localize = (key) => game.i18n.localize("pf2e-ranged-combat.ammunitionSystem.actions.unload." + key)
+const format = (key, data) => game.i18n.format("pf2e-ranged-combat.ammunitionSystem.actions.unload." + key, data)
+
 export async function unload() {
     const { actor, token } = getControlledActorAndToken();
     if (!actor) {
@@ -20,7 +23,7 @@ export async function unload() {
     const conjuredRoundEffect = getEffectFromActor(actor, CONJURED_ROUND_EFFECT_ID, weapon.id);
     const magazineLoadedEffect = getEffectFromActor(actor, MAGAZINE_LOADED_EFFECT_ID, weapon.id);
     if (!loadedEffect && !conjuredRoundEffect && !magazineLoadedEffect) {
-        showWarning(`${weapon.name} is not loaded!`); /*Localization?*/
+        showWarning(format("warningNotLoaded", { weapon: weapon.name }));
         return;
     }
 
@@ -34,8 +37,8 @@ export async function unload() {
                 postInChat(
                     actor,
                     magazineLoadedEffect.img,
-                    `${token.name} unloads ${getFlag(magazineLoadedEffect, "ammunitionName")} from their ${weapon.name}.`, /*Localization?*/
-                    game.i18n.localize("pf2e-ranged-combat.basic-terms.interact"),
+                    format("tokenUnloadsAmmunitionFromWeapon", { token: token.name, ammunition: getFlag(magazineLoadedEffect, "ammunitionName"), weapon: weapon.name }),
+                    game.i18n.localize("PF2E.Actions.Interact.Title"),
                     "1"
                 );
             }
@@ -56,8 +59,8 @@ export async function unload() {
             postInChat(
                 actor,
                 ammunition.img,
-                `${token.name} unloads ${ammunition.name} from their ${weapon.name}.`, /*Localization?*/
-                game.i18n.localize("pf2e-ranged-combat.basic-terms.interact"),
+                format("tokenUnloadsAmmunitionFromWeapon", { token: token.name, ammunition: ammunition.name, weapon: weapon.name }),
+                game.i18n.localize("PF2E.Actions.Interact.Title"),
                 "1"
             );
         } else {
@@ -65,8 +68,8 @@ export async function unload() {
             postInChat(
                 actor,
                 loadedEffect.img,
-                `${token.name} unloads ${getFlag(loadedEffect, "ammunition").name} from their ${weapon.name}.`, /*Localization?*/
-                game.i18n.localize("pf2e-ranged-combat.basic-terms.interact"),
+                format("tokenUnloadsAmmunitionFromWeapon", { token: token.name, ammunition: getFlag(loadedEffect, "ammunition").name, weapon: weapon.name }),
+                game.i18n.localize("PF2E.Actions.Interact.Title"),
                 "1"
             );
         }
@@ -75,8 +78,8 @@ export async function unload() {
         postInChat(
             actor,
             loadedEffect.img,
-            `${token.name} unloads their ${weapon.name}`, /*Localization?*/
-            game.i18n.localize("pf2e-ranged-combat.basic-terms.interact"),
+            format("tokenUnloadsWeapon", { token: token.name, weapon: weapon.name }),
+            game.i18n.localize("PF2E.Actions.Interact.Title"),
             "1"
         );
     }
@@ -96,7 +99,7 @@ function getLoadedWeapon(actor) {
             }
             return false;
         },
-        game.i18n.localize("pf2e-ranged-combat.ammunition-system.actions.unload.weapon")
+        localize("noLoadedWeapons")
     );
 }
 

--- a/scripts/ammunition-system/fire-weapon-check.js
+++ b/scripts/ammunition-system/fire-weapon-check.js
@@ -53,13 +53,13 @@ function checkLoadedMagazine(actor, weapon) {
 
     // Check the weapon has a magazine loaded
     if (!magazineLoadedEffect) {
-        showWarning(`${weapon.name} has no magazine loaded!`); /*Localization?*/
+        showWarning(`${weapon.name} has no magazine loaded!`);
         return false;
     }
 
     // Check the magazine has at least one round remaining
     if (getFlag(magazineLoadedEffect, "remaining") < 1) {
-        showWarning(`${weapon.name}'s magazine is empty!`); /*Localization?*/
+        showWarning(`${weapon.name}'s magazine is empty!`);
         return false;
     }
 
@@ -71,7 +71,7 @@ function checkLoadedMagazine(actor, weapon) {
  */
 async function checkLoadedRound(actor, weapon) {
     if (!isLoaded(actor, weapon)) {
-        showWarning(`${weapon.name} is not loaded!`); /*Localization?*/
+        showWarning(`${weapon.name} is not loaded!`);
         return false;
     }
 
@@ -82,7 +82,7 @@ async function checkLoadedRound(actor, weapon) {
     }
 
     if (isFiringBothBarrels(actor, weapon) && !isFullyLoaded(actor, weapon)) {
-        showWarning(`${weapon.name} does not have both barrels loaded!`); /*Localization?*/
+        showWarning(`${weapon.name} does not have both barrels loaded!`);
         return false;
     }
 
@@ -100,7 +100,7 @@ async function checkLoadedRound(actor, weapon) {
 
 function checkChamberLoaded(actor, weapon) {
     if (!getEffectFromActor(actor, CHAMBER_LOADED_EFFECT_ID, weapon.id)) {
-        showWarning(`${weapon.name}'s current chamber is not loaded!`); /*Localization?*/
+        showWarning(`${weapon.name}'s current chamber is not loaded!`);
         return false;
     }
 
@@ -110,13 +110,13 @@ function checkChamberLoaded(actor, weapon) {
 function checkAmmunition(actor, weapon) {
     const ammunition = weapon.ammunition;
     if (!ammunition) {
-        showWarning(`${weapon.name} has no ammunition selected!`); /*Localization?*/
+        showWarning(`${weapon.name} has no ammunition selected!`);
         return false;
     } else if (ammunition.quantity < 1) {
-        showWarning(`${weapon.name} has no ammunition remaining!`); /*Localization?*/
+        showWarning(`${weapon.name} has no ammunition remaining!`);
         return false;
     } else if (isFiringBothBarrels(actor, weapon) && ammunition.quantity < 2) {
-        showWarning(`${weapon.name} does not have enough ammunition to fire both barrels!`); /*Localization?*/
+        showWarning(`${weapon.name} does not have enough ammunition to fire both barrels!`);
         return false;
     }
 

--- a/scripts/ammunition-system/fire-weapon-handler.js
+++ b/scripts/ammunition-system/fire-weapon-handler.js
@@ -3,6 +3,8 @@ import { isFiringBothBarrels } from "./actions/fire-both-barrels.js";
 import { CHAMBER_LOADED_EFFECT_ID, CONJURED_ROUND_EFFECT_ID, CONJURED_ROUND_ITEM_ID, CONJURE_BULLET_IMG, LOADED_EFFECT_ID, MAGAZINE_LOADED_EFFECT_ID } from "./constants.js";
 import { clearLoadedChamber, removeAmmunition, removeAmmunitionAdvancedCapacity } from "./utils.js";
 
+const format = (key, data) => game.i18n.format("pf2e-ranged-combat.ammunitionSystem." + key, data)
+
 export function fireWeapon(actor, weapon, updates) {
     // If the weapon doesn't use ammunition, we don't need to do anything else
     if (!weapon.usesAmmunition) {
@@ -130,7 +132,7 @@ function fireWeaponAmmunition(actor, weapon, updates, ammunitionToFire = 1) {
     if (game.settings.get("pf2e-ranged-combat", "postFullAmmunition")) {
         ammunition.toMessage();
     } else {
-        postInChat(actor, ammunition.img, `${actor.name} fires ${ammunition.name}.`);
+        postInChat(actor, ammunition.img, format("fireWeapon", { actor: actor.name, ammunition: ammunition.name }));
     }
 }
 
@@ -150,7 +152,7 @@ function consumeConjuredRound(actor, weapon, updates) {
     const conjuredRoundEffect = getEffectFromActor(actor, CONJURED_ROUND_EFFECT_ID, weapon.id);
     if (conjuredRoundEffect) {
         updates.delete(conjuredRoundEffect);
-        postInChat(actor, CONJURE_BULLET_IMG, `${actor.name} fires their conjured round.`); /*Localization?*/
+        postInChat(actor, CONJURE_BULLET_IMG, format("fireConjuredRound", { actor: actor.name }));
     }
     return !!conjuredRoundEffect;
 }
@@ -160,6 +162,6 @@ function postAmmunitionAndApplyEffect(actor, weapon, ammunition, updates) {
     if (ammunitionItem && ammunitionItem.level > 0 && game.settings.get("pf2e-ranged-combat", "postFullAmmunition")) {
         ammunitionItem.toMessage();
     } else {
-        postInChat(actor, ammunition.img, `${actor.name} fires ${ammunition.name}.`); /*Localization?*/
+        postInChat(actor, ammunition.img, format("fireWeapon", { actor: actor.name, ammunition: ammunition.name }));
     }
 }

--- a/scripts/ammunition-system/utils.js
+++ b/scripts/ammunition-system/utils.js
@@ -2,6 +2,9 @@ import { ItemSelectDialog } from "../utils/item-select-dialog.js";
 import { getEffectFromActor, getFlag, getFlags, showWarning } from "../utils/utils.js";
 import { CHAMBER_LOADED_EFFECT_ID, CONJURED_ROUND_EFFECT_ID, CONJURED_ROUND_ITEM_ID, LOADED_EFFECT_ID } from "./constants.js";
 
+const localize = (key) => game.i18n.localize("pf2e-ranged-combat.ammunitionSystem.utils." + key)
+const format = (key, data) => game.i18n.format("pf2e-ranged-combat.ammunitionSystem.utils." + key, data)
+
 /**
  * Check if the weapon is fully loaded and, if it is, show a warning
  */
@@ -9,9 +12,9 @@ export function checkFullyLoaded(actor, weapon) {
     const weaponFullyLoaded = isFullyLoaded(actor, weapon);
     if (weaponFullyLoaded) {
         if (weapon.capacity) {
-            showWarning(`${weapon.name} is already fully loaded.`);
+            showWarning(format("warningFullyLoaded", { weapon: weapon.name }));
         } else {
-            showWarning(`${weapon.name} is already loaded.`);
+            showWarning(format("warningLoaded", { weapon: weapon.name }));
         }
     }
     return weaponFullyLoaded;
@@ -64,7 +67,7 @@ export async function getSelectedAmmunition(actor, weapon) {
     if (conjuredRoundEffect) {
         ammunitions.push(
             {
-                name: game.i18n.localize("pf2e-ranged-combat.amunnition-system.utils.conjured-name"),
+                name: "Conjured Round",
                 img: conjuredRoundEffect.img,
                 id: CONJURED_ROUND_ITEM_ID,
                 sourceId: CONJURED_ROUND_ITEM_ID
@@ -74,8 +77,8 @@ export async function getSelectedAmmunition(actor, weapon) {
 
     if (ammunitions.length > 1) {
         return await ItemSelectDialog.getItem(
-            game.i18n.localize("pf2e-ranged-combat.amunnition-system.utils.ammunition-select"),
-            game.i18n.localize("pf2e-ranged-combat.amunnition-system.utils.select"),
+            "Ammunition Select",
+            "Select which ammunition to switch to.",
             new Map([["Loaded Ammunition", ammunitions]])
         );
     } else {

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -24,8 +24,8 @@ Hooks.on(
             "pf2e-ranged-combat",
             "schemaVersion",
             {
-                name: game.i18n.localize("pf2e-ranged-combat.config.schema-version.name"),
-                hint: game.i18n.localize("pf2e-ranged-combat.config.schema-version.hint"),
+                name: game.i18n.localize("pf2e-ranged-combat.config.schemaVersion.name"),
+                hint: game.i18n.localize("pf2e-ranged-combat.config.schemaVersion.hint"),
                 scope: "world",
                 config: false,
                 type: Number,
@@ -37,8 +37,8 @@ Hooks.on(
             "pf2e-ranged-combat",
             "postFullAction",
             {
-                name: game.i18n.localize("pf2e-ranged-combat.config.post-full-action.name"),
-                hint: game.i18n.localize("pf2e-ranged-combat.config.post-full-action.hint"),
+                name: game.i18n.localize("pf2e-ranged-combat.config.postFullAction.name"),
+                hint: game.i18n.localize("pf2e-ranged-combat.config.postFullAction.hint"),
                 scope: "world",
                 config: true,
                 type: Boolean,
@@ -50,8 +50,8 @@ Hooks.on(
             "pf2e-ranged-combat",
             "postFullAmmunition",
             {
-                name: game.i18n.localize("pf2e-ranged-combat.config.post-full-ammunition.name"),
-                hint: game.i18n.localize("pf2e-ranged-combat.config.post-full-ammunition.hint"),
+                name: game.i18n.localize("pf2e-ranged-combat.config.postFullAmmunition.name"),
+                hint: game.i18n.localize("pf2e-ranged-combat.config.postFullAmmunition.hint"),
                 scope: "world",
                 config: true,
                 type: Boolean,
@@ -63,8 +63,8 @@ Hooks.on(
             "pf2e-ranged-combat",
             "preventFireNotLoaded",
             {
-                name: game.i18n.localize("pf2e-ranged-combat.config.prevent-fire.name"),
-                hint: game.i18n.localize("pf2e-ranged-combat.config.prevent-fire.hint"),
+                name: game.i18n.localize("pf2e-ranged-combat.config.preventFireNotLoaded.name"),
+                hint: game.i18n.localize("pf2e-ranged-combat.config.preventFireNotLoaded.hint"),
                 scope: "world",
                 config: true,
                 type: Boolean,
@@ -76,8 +76,8 @@ Hooks.on(
             "pf2e-ranged-combat",
             "advancedAmmunitionSystemPlayer",
             {
-                name: game.i18n.localize("pf2e-ranged-combat.config.advanced-ammunition.name"),
-                hint: game.i18n.localize("pf2e-ranged-combat.config.advanced-ammunition.hint"),
+                name: game.i18n.localize("pf2e-ranged-combat.config.advancedAmmunitionSystemPlayer.name"),
+                hint: game.i18n.localize("pf2e-ranged-combat.config.advancedAmmunitionSystemPlayer.hint"),
                 scope: "world",
                 config: true,
                 type: Boolean,
@@ -89,8 +89,8 @@ Hooks.on(
             "pf2e-ranged-combat",
             "advancedThrownWeaponSystemPlayer",
             {
-                name: game.i18n.localize("pf2e-ranged-combat.config.advanced-thrown-weapon.name"),
-                hint: game.i18n.localize("pf2e-ranged-combat.config.advanced-thrown-weapon.hint"),
+                name: game.i18n.localize("pf2e-ranged-combat.config.advancedThrownWeaponSystemPlayer.name"),
+                hint: game.i18n.localize("pf2e-ranged-combat.config.advancedThrownWeaponSystemPlayer.hint"),
                 scope: "world",
                 config: true,
                 type: Boolean,
@@ -102,16 +102,16 @@ Hooks.on(
             "pf2e-ranged-combat",
             "requiredPermissionToShowMessages",
             {
-                name: game.i18n.localize("pf2e-ranged-combat.config.required-permission.name"),
-                hint: game.i18n.localize("pf2e-ranged-combat.config.required-permission.hint"),
+                name: game.i18n.localize("pf2e-ranged-combat.config.requiredPermissionToShowMessages.name"),
+                hint: game.i18n.localize("pf2e-ranged-combat.config.requiredPermissionToShowMessages.hint"),
                 scope: "world",
                 config: true,
                 type: Number,
                 choices: {
-                    0: game.i18n.localize("pf2e-ranged-combat.config.required-permission.none"),
-                    1: game.i18n.localize("pf2e-ranged-combat.config.required-permission.limited"),
-                    2: game.i18n.localize("pf2e-ranged-combat.config.required-permission.observer"),
-                    3: game.i18n.localize("pf2e-ranged-combat.config.required-permission.owner")
+                    0: game.i18n.localize("OWNERSHIP.NONE"),
+                    1: game.i18n.localize("OWNERSHIP.LIMITED"),
+                    2: game.i18n.localize("OWNERSHIP.OBSERVER"),
+                    3: game.i18n.localize("OWNERSHIP.OWNER")
                 },
                 default: 0
             }
@@ -121,8 +121,8 @@ Hooks.on(
             "pf2e-ranged-combat",
             "hideTokenIcons",
             {
-                name: game.i18n.localize("pf2e-ranged-combat.config.hide-token.name"),
-                hint: game.i18n.localize("pf2e-ranged-combat.config.hide-token.hint"),
+                name: game.i18n.localize("pf2e-ranged-combat.config.hideTokenIcons.name"),
+                hint: game.i18n.localize("pf2e-ranged-combat.config.hideTokenIcons.hint"),
                 scope: "client",
                 config: true,
                 type: Boolean,

--- a/scripts/hunt-prey/hunt-prey.js
+++ b/scripts/hunt-prey/hunt-prey.js
@@ -19,7 +19,7 @@ export async function huntPrey() {
 
     const huntPreyAction = getItemFromActor(actor, HUNT_PREY_ACTION_ID);
     if (!huntPreyAction) {
-        showWarning(`${token.name} does not have the Hunt Prey action.`); /*Localization?*/
+        showWarning(game.i18n.format("pf2e-ranged-combat.huntPrey.warningNoAction", { tokenName: token.name }));
         return;
     }
 
@@ -28,10 +28,10 @@ export async function huntPrey() {
     const hasTripleThreat = !!getItemFromActor(actor, TRIPLE_THREAT_FEAT_ID);
 
     const maxTargets = hasTripleThreat
-        ? { num: 3, word: "three" }
+        ? { num: 3, word: game.i18n.localize("pf2e-ranged-combat.huntPrey.maxTargetsThree") }
         : hasDoublePrey
-            ? { num: 2, word: "two" }
-            : { num: 1, word: "one" };
+            ? { num: 2, word: game.i18n.localize("pf2e-ranged-combat.huntPrey.maxTargetsTwo") }
+            : { num: 1, word: game.i18n.localize("pf2e-ranged-combat.huntPrey.maxTargetsOne") };
 
     const targets = getTargets(maxTargets);
     if (!targets.length) {
@@ -46,23 +46,23 @@ export async function huntPrey() {
     {
         const remainingTargets = maxTargets.num - targets.length;
         const remainingTargetsText = remainingTargets === 2
-            ? game.i18n.localize("pf2e-ranged-combat.hunt-prey.two-allies")
+            ? game.i18n.localize("pf2e-ranged-combat.huntPrey.shareWithTwo")
             : remainingTargets === 1 && hasSharedPrey
-                ? game.i18n.localize("pf2e-ranged-combat.hunt-prey.one-ally")
+                ? game.i18n.localize("pf2e-ranged-combat.huntPrey.shareWithOne")
                 : "";
 
         const showTokenNames = !game.settings.get("pf2e", "metagame_tokenSetsNameVisibility");
         const targetNames = targets.map(target => (showTokenNames || target.document.playersCanSeeName) ? target.name : "Unknown Token");
-
+        const targetData = { tokenName: token.name, target1: targetNames[0], target2: targetNames[1], target3: targetNames[2] };
         await postActionInChat(huntPreyAction);
         await postInChat(
             actor,
             HUNT_PREY_IMG,
             targets.length === 3
-                ? `${token.name} makes ${targetNames[0]}, ${targetNames[1]}, and ${targetNames[2]} their hunted prey.` /*Localization?*/
+                ? game.i18n.format("pf2e-ranged-combat.huntPrey.huntThreeTargets", targetData)
                 : targets.length === 2
-                    ? `${token.name} makes ${targetNames[0]} and ${targetNames[1]} their hunted prey${remainingTargetsText}.` /*Localization?*/
-                    : `${token.name} makes ${targetNames[0]} their hunted prey${remainingTargetsText}.` /*Localization?*/
+                    ? game.i18n.format("pf2e-ranged-combat.huntPrey.huntTwoTargets", targetData) + remainingTargetsText + "."
+                    : game.i18n.format("pf2e-ranged-combat.huntPrey.huntOneTarget", targetData) + remainingTargetsText + "."
             ,
             huntPreyAction.name,
             1
@@ -104,10 +104,10 @@ function getTargets(maxTargets) {
     const targetTokens = canvas.tokens.placeables.filter(token => targetTokenIds.includes(token.id));
 
     if (!targetTokens.length) {
-        showWarning(game.i18n.localize("pf2e-ranged-combat.hunt-prey.no-target"));
+        showWarning(game.i18n.localize("pf2e-ranged-combat.huntPrey.warningNoTarget"));
         return [];
     } else if (targetTokens.length > maxTargets.num) {
-        showWarning(`You may only have ${maxTargets.word} hunted prey.`); /*Localization?*/
+        showWarning(game.i18n.format("pf2e-ranged-combat.huntPrey.warningTooManyTargets", { maxTargets: maxTargets.word }));
         return [];
     } else {
         return targetTokens;

--- a/scripts/npc-weapon-system/npc-weapon-system.js
+++ b/scripts/npc-weapon-system/npc-weapon-system.js
@@ -1,6 +1,8 @@
 import { findGroupStacks } from "../thrown-weapons/change-carry-type.js";
 import { getControlledActor, getControlledActorAndToken } from "../utils/utils.js";
 
+const localize = (key) => game.i18n.format("pf2e-ranged-combat.npcWeaponSystem." + key)
+
 export function npcWeaponConfiguration() {
     const actor = getControlledActor();
     if (!actor) {
@@ -8,21 +10,21 @@ export function npcWeaponConfiguration() {
     }
 
     if (actor.type !== "npc") {
-        ui.notifications.warn(game.i18n.localize("pf2e-ranged-combat.npc-weapon-system.ui-notification"));
+        ui.notifications.warn(localize("warningNpcOnly"));
         return;
     }
 
     new Dialog(
         {
-            title: game.i18n.localize("pf2e-ranged-combat.npc-weapon-system.title"),
+            title: localize("dialog.title"),
             content: buildContent(actor),
             buttons: {
                 ok: {
-                    label: game.i18n.localize("pf2e-ranged-combat.npc-weapon-system.ok"),
+                    label: localize("dialog.done"),
                     callback: ($html) => saveChanges($html, actor)
                 },
                 cancel: {
-                    label: game.i18n.localize("pf2e-ranged-combat.npc-weapon-system.cancel")
+                    label: localize("dialog.cancel")
                 }
             }
         }
@@ -42,36 +44,36 @@ function buildContent(actor) {
 
     content += `
         <div>
-            Here, you can configure the NPC to be used by the PF2e Ranged Combat module.
+            ${localize("dialog.hint")}
         </div>
 
         <fieldset style="border: 1px solid #a1a1a1; padding: 5px;">
-            <legend>General</legend>
+            <legend>${localize("dialog.legendGeneral")}</legend>
             <form>
                 <div class = "form-group">
                     <input type="checkbox" id="enableAdvancedAmmunitionSystem" name="enableAdvancedAmmunitionSystem" ${enableAdvancedAmmunitionSystem ? `checked` : ``}>
-                    <label>Enable Advanced Ammunition System</label>
+                    <label>${localize("dialog.enableAmmunition")}</label>
                 </div>
             </form>
             <form>
                 <div class = "form-group">
                     <input type="checkbox" id="enableAdvancedThrownWeaponSystem" name="enableAdvancedThrownWeaponSystem" ${enableAdvancedThrownWeaponSystem ? `checked` : ``}>
-                    <label>Enable Advanced Thrown Weapon System</label>
+                    <label>${localize("dialog.enableThrown")}</label>
                 </div>
             </form>
         </fieldset>
         <hr/>
-    `; /*Localization?*/
+    `;
 
     content += `
         <fieldset style="border: 1px solid #a1a1a1; padding: 5px;">
-            <legend>Weapon Mapping</legend>
+            <legend>${localize("dialog.legendMapping")}</legend>
             <div>
-                You can map each of your NPC's attacks to a weapon and ammunition, so it is treated like a PC's weapon by the module.
+            ${localize("dialog.mappingHint")}
             </div>
         
             <form>
-    `; 
+    `;
 
     for (const attack of attacks) {
         const weaponId = attack.flags["pf2e-ranged-combat"]?.weaponId;
@@ -79,9 +81,9 @@ function buildContent(actor) {
 
         content += `
             <fieldset style="border: 1px solid #a1a1a1; padding: 5px;">
-                <legend>${attack.name} [${attack.system.weaponType.value === "melee" ? "Melee" : "Ranged"}]</legend>
+                <legend>${attack.name} [${attack.system.weaponType.value === "melee" ? localize("dialog.weaponTypeMelee") : localize("dialog.weaponTypeRanged")}]</legend>
                 <div class="form-group">
-                    <label>Weapon</label>
+                    <label>${localize("dialog.labelWeapon")}</label>
                     <select id="${attack.id}-weapon" name="${attack.id}-weapon">
                         <option/>
         `;
@@ -98,7 +100,7 @@ function buildContent(actor) {
         if (isRanged && usesAmmunition) {
             content += `
                 <div class="form-group">
-                    <label>Ammunition</label>
+                    <label>${localize("dialog.labelAmmunition")}</label>
                     <select id="${attack.id}-ammo" name="${attack.id}-ammo">
                         <option/>`;
 

--- a/scripts/thrown-weapons/throw-weapon-check.js
+++ b/scripts/thrown-weapons/throw-weapon-check.js
@@ -15,12 +15,12 @@ export async function checkThrownWeapon(weapon) {
     const groupStacks = findGroupStacks(weapon);
     const equippedWeapons = groupStacks.filter(stack => stack.isEquipped);
     if (!equippedWeapons.length) {
-        showWarning(`${weapon.name} is not equipped!`);
+        showWarning(game.i18n.format("pf2e-ranged-combat.thrownWeapons.warningNotEquipped", { weapon: weapon.name }));
         return false;
     }
 
     if (!equippedWeapons.filter(stack => stack.quantity).length) {
-        showWarning(`You have no ${weapon.name} left!`);
+        showWarning(game.i18n.format("pf2e-ranged-combat.thrownWeapons.warningNoAmmoLeft", { weapon: weapon.name }));
         return false;
     }
 

--- a/scripts/utils/migrations/migration-001-multiple-ammunitions.js
+++ b/scripts/utils/migrations/migration-001-multiple-ammunitions.js
@@ -6,7 +6,7 @@ export class Migration001MultipleAmmunitions {
     version = 1;
 
     async runMigration() {
-        console.info(game.i18n.localize("pf2e-ranged-combat.utils.migration.multiple-ammunitions.console-info"));
+        console.info(game.i18n.localize("pf2e-ranged-combat.utils.migration.multipleAmmunitions.consoleInfo"));
 
         const actors = game.actors.contents;
 
@@ -67,7 +67,7 @@ export class Migration001MultipleAmmunitions {
                 if (chamberLoadedEffect) {
                     if (conjuredRoundEffect) {
                         currentAmmunition = {
-                            name: game.i18n.localize("pf2e-ranged-combat.utils.migration.multiple-ammunitions.conjured-round"),
+                            name: "Conjured Round",
                             img: CONJURE_BULLET_IMG,
                             id: CONJURED_ROUND_ITEM_ID,
                             sourceId: CONJURED_ROUND_ITEM_ID

--- a/scripts/utils/migrations/migration-002-thrown-weapon-groups.js
+++ b/scripts/utils/migrations/migration-002-thrown-weapon-groups.js
@@ -5,7 +5,7 @@ export class Migration002ThrownWeaponGroups {
     version = 2;
 
     async runMigration() {
-        console.info(game.i18n.localize("pf2e-ranged-combat.utils.migration.thrown-weapon-groups.console-info"));
+        console.info(game.i18n.localize("pf2e-ranged-combat.utils.migration.thrownWeaponGroups.consoleInfo"));
 
         const actors = game.actors.contents;
 

--- a/scripts/utils/migrations/migration-003-hunted-prey-array.js
+++ b/scripts/utils/migrations/migration-003-hunted-prey-array.js
@@ -5,7 +5,7 @@ export class Migration003HuntedPreyArray {
     version = 3;
 
     async runMigration() {
-        console.info(game.i18n.localize("pf2e-ranged-combat.utils.migration.hunted-prey.console-info"));
+        console.info(game.i18n.localize("pf2e-ranged-combat.utils.migration.huntedPrey.consoleInfo"));
 
         const actors = game.actors.contents;
 

--- a/scripts/utils/utils.js
+++ b/scripts/utils/utils.js
@@ -1,3 +1,5 @@
+const localize = (key) => game.i18n.localize("pf2e-ranged-combat.utils." + key)
+
 export class Updates {
     constructor(actor) {
         this.actor = actor;
@@ -246,16 +248,16 @@ export function showWarning(warningMessage) {
             {
                 "title": "PF2e Ranged Combat",
                 "content": `
-                    <p>You cannot fire this weapon because: ${warningMessage}<p>
-                    <p>This is a feature of the PF2e Ranged Combat module. 
-                    You can learn how to use the module <a href="https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/blob/main/README.md">here</a>.</p>
+                    <p>${localize("warningDialog1")} ${warningMessage}<p>
+                    <p>${localize("warningDialog2")} 
+                    ${localize("warningDialog3")}</p>
                 `,
                 "buttons": {
                     "ok": {
-                        "label": "OK",
+                        "label": localize("buttonOK"),
                     },
                     "doNotShowAgain": {
-                        "label": "OK (Do not show again)",
+                        "label": localize("buttonDoNotShowAgain"),
                         "callback": () => game.settings.set("pf2e-ranged-combat", "doNotShowWarningAgain", true)
                     }
                 }


### PR DESCRIPTION
Hello.
This should have the localization of all the strings, including formatted ones. My string naming schema is different from the one you used (I've based it on PF2e Workbench module).
I've included a per-file version of `localize` and `format` functions to shorten the localization keys in file. A drawback of this is that searching for them is now less trivial, but I've tried to maintain the project structure and order of strings in the language file.
I've removed localization strings for user roles and basic PF2e actions (like Interact), since those are covered by the Foundry and the system translations.

Additionally, I've fixed the module.json so that it successfully finds the localization file.
#120 