### PR TITLE
Fix libWrapper error caused by a renamed method

### DIFF
--- a/scripts/fire-weapon-hook.js
+++ b/scripts/fire-weapon-hook.js
@@ -17,14 +17,14 @@ Hooks.on(
          */
         libWrapper.register(
             "pf2e-ranged-combat",
-            "CONFIG.PF2E.Actor.documentClasses.character.prototype.adjustCarryType",
+            "CONFIG.PF2E.Actor.documentClasses.character.prototype.changeCarryType",
             changeCarryType,
             "MIXED"
         );
 
         libWrapper.register(
             "pf2e-ranged-combat",
-            "CONFIG.PF2E.Actor.documentClasses.npc.prototype.adjustCarryType",
+            "CONFIG.PF2E.Actor.documentClasses.npc.prototype.changeCarryType",
             changeCarryType,
             "MIXED"
         );


### PR DESCRIPTION
 It happened in 5.12.7, I think.