### PR TITLE
Fix visual error with traits in chat messages generated by the module

### DIFF
--- a/scripts/ammunition-system/auxiliary-actions.js
+++ b/scripts/ammunition-system/auxiliary-actions.js
@@ -306,7 +306,7 @@ async function changeCarryType(weapon, subAction, hands) {
                 subtitle: `PF2E.Actions.Interact.${subAction}.Title`,
                 glyph: "1",
             },
-            traits: traitSlugToObject("manipulate")
+            traits: [traitSlugToObject("manipulate")]
         }
     );
     const content = await renderTemplate(


### PR DESCRIPTION
When interacting with an item with the buttons added by the module, the trait (manipulate) wouldn't be displayed properly in the generated chat message:

![image](https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/assets/68966233/3bdade80-b727-4106-aa4b-582d320a5041)
![image](https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/assets/68966233/67147217-47b1-48de-a6a8-6db9b88da73b)

The first and second chat messages show the bugged output, the last shows the Manipulate trait being properly displayed (expected output). 

The cause of this is the trait object provided was a single trait object, but the template expects an array of such trait objects to be passed to it. It was reading each attribute of the provided trait object separately and improperly.

The fix that this pull request provides is just to place the trait object in an array, as that is what the chat message template is expecting.