### PR TITLE
Fix action glyph not appearing on interact when reloading

### DIFF
--- a/scripts/utils/utils.js
+++ b/scripts/utils/utils.js
@@ -261,7 +261,7 @@ export async function postActionInChat(action) {
 
 export async function postInChat(actor, img, message, actionName = "", numActions = "") {
     const content = await renderTemplate("./systems/pf2e/templates/chat/action/content.hbs", { imgPath: img, message: message, });
-    const flavor = await renderTemplate("./systems/pf2e/templates/chat/action/flavor.hbs", { action: { title: actionName, typeNumber: String(numActions) } });
+    const flavor = await renderTemplate("./systems/pf2e/templates/chat/action/flavor.hbs", { action: { title: actionName, glyph: String(numActions) } });
 
     await ChatMessage.create({
         type: CONST.CHAT_MESSAGE_TYPES.EMOTE,


### PR DESCRIPTION
The action symbols were not appearing when items were reloaded/unloaded: 
![image](https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/assets/68966233/ee0a5a00-0988-4490-b72d-b471b1c416ba)

Now, they properly print their action glyph in the chat message:
![image](https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/assets/68966233/acbd738c-f88d-4dbf-b4d1-1f1df1f37141)

This also works with Reload 2 weapons (before and after):
![image](https://github.com/JDCalvert/FVTT-PF2e-Ranged-Combat/assets/68966233/5f5fdd01-ddb3-41e7-9ecb-4b6218256d87)
