### PR TITLE
wrap the strikes in prepareStrike to set consumeAmmo to false

### DIFF
--- a/scripts/ammunition-system/disasble-ammo-consumption.js
+++ b/scripts/ammunition-system/disasble-ammo-consumption.js
@@ -1,0 +1,12 @@
+export function disableAmmoConsumption(strike) {
+    const newVariants = strike.variants.map(variant => {
+        return {
+            ...variant,
+            roll: (...args) => {
+                return variant.roll(...[{ ...(args[0]), consumeAmmo: false}, args.slice(1)]);
+            }
+        };
+    });
+    strike.variants = newVariants;
+    strike.attack = strike.roll = strike.variants[0].roll;
+}

--- a/scripts/libwrapper-hooks.js
+++ b/scripts/libwrapper-hooks.js
@@ -1,6 +1,7 @@
 import { handleWeaponFired as handleAlchemicalCrossbowFired } from "./actions/alchemical-crossbow.js";
 import { handleWeaponFiredAlchemicalShot } from "./actions/alchemical-shot.js";
 import { buildAuxiliaryActions } from "./ammunition-system/auxiliary-actions.js";
+import { disableAmmoConsumption } from "./ammunition-system/disasble-ammo-consumption.js";
 import { checkLoaded } from "./ammunition-system/fire-weapon-check.js";
 import { fireWeapon } from "./ammunition-system/fire-weapon-handler.js";
 import { handleWeaponFired as crossbowFeatsHandleFired } from "./feats/crossbow-feats.js";
@@ -114,6 +115,7 @@ export function initialiseLibWrapperHooks() {
         function(wrapper, ...args) {
             const strike = wrapper(...args);
             buildAuxiliaryActions(strike);
+            disableAmmoConsumption(strike);
             return strike;
         },
         "WRAPPER"


### PR DESCRIPTION
fixes #174 

Since there is a check at the start of a strike's `roll` functions for the `consumeAmmo` parameter, separate from the call to the `consumeAmmo()` function which is already patched, wrap the roll functions to force the paramter to false.