### PR TITLE
Add author to Switch Ammunition macro

### DIFF
--- a/packs-source/macros/Switch_Ammunition_K9jrrGLnMF23WKET.json
+++ b/packs-source/macros/Switch_Ammunition_K9jrrGLnMF23WKET.json
@@ -2,6 +2,7 @@
   "_id": "K9jrrGLnMF23WKET",
   "name": "Switch Ammunition",
   "type": "script",
+  "author": "I90qJ09IMT0McqwG",
   "scope": "global",
   "img": "modules/pf2e-ranged-combat/art/switch-ammunition.webp",
   "command": "game.pf2eRangedCombat.switchAmmunition();",


### PR DESCRIPTION
Causes warnings at load time without it.

node[959]: FoundryVTT | 2024-06-14 23:17:30 | [warn]  [K9jrrGLnMF23WKET] validation errors:
node[959]:   author: may not be undefined
node[959]: Error:  [K9jrrGLnMF23WKET] validation errors:
node[959]:   author: may not be undefined