### PR TITLE
Translations update from Foundry Hub - Weblate

### DIFF
--- a/lang/pl.json
+++ b/lang/pl.json
@@ -52,7 +52,19 @@
             "huntOneTarget": "{token} czyni {target1} celem swojego łowów na zwierzynę.",
             "warningNoTarget": "Nie wybrano celu.",
             "warningTooManyTargets": "Twoja maksymalna liczba celów łowów na zwierzynę to: {maxTargets}.",
-            "versusPreyAttack": "Przeciw atakom Naznaczonej Ofiary"
+            "versusPreyAttack": "Przeciw atakom Naznaczonej Ofiary",
+            "precision": {
+                "attackNumber": "Atak na Naznaczoną ofiarę",
+                "first": "Pierwszy",
+                "second": "Drugi",
+                "third": "Trzeci",
+                "subsequent": "Późniejsze"
+            },
+            "huntersEdge": {
+                "flurry": "Grad Ciosów",
+                "precision": "Precyzja",
+                "outwit": "Przechytrzenie"
+            }
         },
         "thrownWeapons": {
             "warningNotEquipped": "Nie jesteś wyposażony w: {weapon}!",
@@ -253,7 +265,8 @@
             "noTarget": "Musisz wybrać jeden cel, który stanie się twoim zwierzęcym towarzyszem.",
             "rangersAnimalCompanion": "Zwierzęcy Towarzysz postaci {actor}",
             "linkedCompanion": "{companion} jest teraz towarzyszem {master}.",
-            "noAnimalCompanionFeat": "{actor} nie posiada atutu łowcy Towarzysz Zwierząt."
+            "noAnimalCompanionFeat": "{actor} nie posiada atutu łowcy Towarzysz Zwierząt.",
+            "masterfulAnimalCompanion": "Mistrzowski Towarzysz {actor}"
         },
         "feat": {
             "fakeOut": {


### PR DESCRIPTION
Translations update from [Foundry Hub - Weblate](https://weblate.foundryvtt-hub.com) for [PF2e Ranged Combat/main](https://weblate.foundryvtt-hub.com/projects/pf2e-ranged-combat/main/).



Current translation status:

![Weblate translation status](https://weblate.foundryvtt-hub.com/widget/pf2e-ranged-combat/main/horizontal-auto.svg)