### PR TITLE
Extend Alchemical Crossbow bomb name translation support by using babele-provided original name

### DIFF
--- a/scripts/actions/alchemical-crossbow.js
+++ b/scripts/actions/alchemical-crossbow.js
@@ -220,7 +220,7 @@ function getElementalBomb(actor, token) {
         weapon =>
             weapon.baseType === "alchemical-bomb"
             && DAMAGE_TYPES.some(element => weapon.traits.has(element))
-            && weapon.name.includes(localize("lesser"))
+            && (weapon.name.includes(localize("lesser")) || weapon.name.toLowerCase().includes("lesser") || weapon.flags.babele?.originalName?.includes("Lesser"))
             && weapon.quantity > 0,
         format("warningNoLesserAlchemicalBombs", { token: token.name })
     );


### PR DESCRIPTION
Extends Alchemical Crossbow lesser bomb matching in localized games by using original name provided in babele flag. Used in cases where "Lesser" might be translated differently depending on an item it refers to.

Here are the cases that are covered
1) As before, matches an item that has localized "lesser" in its name.
2) Matches an item that has English "lesser" in its name (in case an item name is not localized)
3) Uses babele-provided original name data stored in item's flag, and matches "Lesser" on it. Works when case 1) is not sufficient.

The case 1) should still be there for user-made items (not from compendium).