### PR TITLE
Fix issue when adding hunt prey options

### DIFF
--- a/scripts/advanced-weapon-system/initialise.js
+++ b/scripts/advanced-weapon-system/initialise.js
@@ -22,18 +22,21 @@ export function initialiseAdvancedWeaponSystem() {
                 variant => {
                     const roll = variant.roll;
                     variant.roll = params => {
+                        const extraOptions = [];
                         // Disable the system's ammunition consumption - we handle it ourselves
                         if (params.consumeAmmo === false) {
-                            params.options ??= [];
-                            params.options.push("skip-post-processing")
+                            extraOptions.push("skip-post-processing");
                         }
-                        
+
                         params.consumeAmmo = false;
 
                         // If our current target is our hunted prey, add the "hunted-prey" roll option
                         if (isTargetHuntedPrey(actor)) {
-                            params.options ??= [];
-                            params.options.push("hunted-prey");
+                            extraOptions.push("hunted-prey");
+                        }
+
+                        if (extraOptions.length > 0) {
+                            params.options = new Set([...(params.options ?? []), ...extraOptions]);
                         }
 
                         return roll(params);
@@ -48,8 +51,7 @@ export function initialiseAdvancedWeaponSystem() {
                 const damage = strike[method];
                 strike[method] = async params => {
                     if (isTargetHuntedPrey(actor)) {
-                        params.options ??= [];
-                        params.options.push("hunted-prey");
+                        params.options = new Set([...(params.options ?? []), "hunted-prey"]);
                     }
 
                     return damage(params);


### PR DESCRIPTION
The existing options in the roll params can be either an array or a set, but the existing code, which uses `.append()`, doesn't work on a set.

Adding to the passed in options array/set also leaves it modified after the function rerturns.  If the caller re-uses it, for instance rolling for the whole party, it will have had options like hunted-prey added to it on subsequent rolls.  The pf2e system code doesn't modify the parameters.

Convert an existing option list to a new set and add the new options to it, which is what the pf2e system code does, to solve both problems at once.