### PR TITLE
Fix label of strike count roll option in animal companion feat

### DIFF
--- a/packs-source/feats/Ranger_s_Animal_Companion_bmDVg2hU3CSAZGJ8.json
+++ b/packs-source/feats/Ranger_s_Animal_Companion_bmDVg2hU3CSAZGJ8.json
@@ -128,7 +128,7 @@
             "value": "third-attack"
           },
           {
-            "label": "pf2e-ranged-combat.huntPrey.precision.third",
+            "label": "pf2e-ranged-combat.huntPrey.precision.subsequent",
             "value": "subsequent-attack"
           }
         ],


### PR DESCRIPTION
The second third should be subsequent.