### PR TITLE
fix: update stale Off-Guard UUID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 8.0.3 - 2026-03-15 (Pathfinder 2e 7.11.x / 6.12.4)
+### Fix
+- Fix stale Off-Guard effect UUID in Fake Out chat link.
+
 ## 8.0.2 - 2026-02-27 (Pathfinder 2e 7.10.1 / 6.12.4)
 - Update French translation.
 

--- a/scripts/feats/fake-out.js
+++ b/scripts/feats/fake-out.js
@@ -182,7 +182,7 @@ function postFakeOutMessage(actor, message, bonus) {
             actionName: game.i18n.localize("pf2e-ranged-combat.feat.fakeOut.name"),
             actionSymbol: "r",
             traits: ["visual"],
-            link: bonus ? "Compendium.pf2e.other-effects.Item.AHMUpMbaVkZ5A1KX" : null
+            link: bonus ? "Compendium.pf2e.other-effects.Item.y1GwyXv7iOf8DhBg" : null
         }
     );
 }


### PR DESCRIPTION
The Off-Guard effect UUID in the Fake Out chat link (`AHMUpMbaVkZ5A1KX`) does not match the PF2e system's `other-effects` compendium. The actual UUID for `Effect: Off-Guard until end of your next turn` is `y1GwyXv7iOf8DhBg` and has been since at least the flat-footed→off-guard rename in PF2e commit `7287f99` (2023-07-28). The old UUID doesn't appear anywhere in the PF2e system's git history.

This fixes the clickable Off-Guard link in the Fake Out chat message.