### PR TITLE
fix: recognize dynamically-added thrown trait from Hurl at the Horizon

### DIFF
--- a/scripts/thrown-weapons/throw-weapon-check.js
+++ b/scripts/thrown-weapons/throw-weapon-check.js
@@ -21,7 +21,9 @@ async function checkThrownWeapon({ weapon }) {
     }
 
     // If the weapon isn't thrown, then we don't need to do anything
-    const isThrownWeapon = weapon.isRanged && Array.from(weapon.traits).some(trait => trait.startsWith("thrown"));
+    // Note: we don't gate on isRanged here because feats like Hurl at the Horizon
+    // can dynamically add the thrown trait to a melee weapon via ItemAlteration
+    const isThrownWeapon = Array.from(weapon.traits).some(trait => trait.startsWith("thrown"));
     if (!isThrownWeapon) {
         return true;
     }

--- a/scripts/thrown-weapons/throw-weapon-processor.js
+++ b/scripts/thrown-weapons/throw-weapon-processor.js
@@ -18,7 +18,9 @@ function handleThrownWeapon({ weapon }) {
     }
 
     // If the weapon isn't thrown, then we don't need to do anything
-    const isThrownWeapon = weapon.isRanged && Array.from(weapon.traits).some(trait => trait.startsWith("thrown"));
+    // Note: we don't gate on isRanged here because feats like Hurl at the Horizon
+    // can dynamically add the thrown trait to a melee weapon via ItemAlteration
+    const isThrownWeapon = Array.from(weapon.traits).some(trait => trait.startsWith("thrown"));
     if (!isThrownWeapon) {
         return;
     }

--- a/scripts/thrown-weapons/utils.js
+++ b/scripts/thrown-weapons/utils.js
@@ -13,7 +13,9 @@ export function findGroupStacks(weapon) {
 }
 
 /**
- * Determine if this is a valid item
+ * Determine if this is a valid thrown weapon item.
+ * Checks both stored traits and the synthesized trait set to catch
+ * dynamically-added thrown traits (e.g. Hurl at the Horizon via ItemAlteration).
  *
  * @param {WeaponPF2e} item
  * @returns {boolean}
@@ -21,7 +23,8 @@ export function findGroupStacks(weapon) {
 export function isThrownWeaponUsingAdvancedThrownWeaponSystem(item) {
     return useAdvancedThrownWeaponSystem(item.actor)
         && item.type === "weapon"
-        && item.system.traits.value.some(trait => trait.startsWith("thrown"));
+        && (item.system.traits.value.some(trait => trait.startsWith("thrown"))
+            || item.traits?.some(trait => trait.startsWith("thrown")));
 }
 
 /**


### PR DESCRIPTION
Fixes #236

The Exemplar feat Hurl at the Horizon adds `thrown-15` to a melee weapon ikon via `ItemAlteration` rules. The module's thrown weapon detection required `isRanged` to be true, which fails for these weapons — `isRanged` checks `system.range`, which is set during the weapon's `prepareBaseData()` before `ItemAlteration` from other items runs. The trait is present but the range gate blocks detection.

Removed the `isRanged` gate from thrown weapon detection in three files. The thrown trait check alone is sufficient — all natively thrown weapons also have the trait, so no existing behavior changes.